### PR TITLE
Feature/auth

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.dogGetDrunk.meetjyou.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Business
+    DUPLICATE("Duplicate value"),
+    NOT_FOUND("Value not found"),
+
+    // User
+    DUPLICATE_EMAIL("Duplicate email"),
+    NOT_FOUND_EMAIL("Email not found");
+
+//    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
@@ -13,7 +13,13 @@ public enum ErrorCode {
 
     // User
     DUPLICATE_EMAIL("Duplicate email"),
-    NOT_FOUND_EMAIL("Email not found");
+    NOT_FOUND_EMAIL("Email not found"),
+
+    // JWT
+    TOKEN_COMMON("The token has an issue."),
+    EXPIRED_TOKEN("The token has expired."),
+    INCORRECT_TOKEN_SUBJECT("The subject in the token is incorrect."),
+    INVALID_AUTHORIZATION_HEADER("This authorization header is invalid");
 
 //    private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 
     // User
     DUPLICATE_EMAIL("Duplicate email"),
-    NOT_FOUND_EMAIL("Email not found"),
+    EMAIL_NOT_FOUND("Email not found"),
+    USER_NOT_FOUND("User not found"),
 
     // JWT
     TOKEN_COMMON("The token has an issue."),

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorResponse.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.dogGetDrunk.meetjyou.common.exception;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private List<String> values = new ArrayList<>();
+
+    public ErrorResponse(int status, ErrorCode errorCode) {
+        this.status = status;
+        this.message = errorCode.getMessage();
+    }
+
+    public ErrorResponse(int status, ErrorCode errorCode, String value) {
+        this(status, errorCode);
+        this.values = List.of(value);
+    }
+
+    public ErrorResponse(int status, ErrorCode errorCode, List<String> values) {
+        this(status, errorCode);
+        this.values = values;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,38 @@
+package com.dogGetDrunk.meetjyou.common.exception;
+
+import com.dogGetDrunk.meetjyou.common.exception.business.DuplicateException;
+import com.dogGetDrunk.meetjyou.common.exception.business.NotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicateException.class)
+    protected ResponseEntity<ErrorResponse> handleDuplicateException(DuplicateException e) {
+        log.info("Handle DuplicateException", e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        String value = e.getValue();
+        int status = HttpStatus.CONFLICT.value();
+        ErrorResponse errorResponse = new ErrorResponse(status, errorCode, value);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotExistException(NotFoundException e) {
+        log.info("Handle NotExistException", e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        String value = e.getValue();
+        int status = HttpStatus.NOT_FOUND.value();
+        ErrorResponse errorResponse = new ErrorResponse(status, errorCode, value);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.dogGetDrunk.meetjyou.common.exception;
 
+import com.dogGetDrunk.meetjyou.common.exception.business.CustomExpiredJwtException;
+import com.dogGetDrunk.meetjyou.common.exception.business.CustomJwtException;
 import com.dogGetDrunk.meetjyou.common.exception.business.DuplicateException;
+import com.dogGetDrunk.meetjyou.common.exception.business.IncorrectJwtSubjectException;
 import com.dogGetDrunk.meetjyou.common.exception.business.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -31,6 +34,18 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = e.getErrorCode();
         String value = e.getValue();
         int status = HttpStatus.NOT_FOUND.value();
+        ErrorResponse errorResponse = new ErrorResponse(status, errorCode, value);
+
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));
+    }
+
+    @ExceptionHandler(CustomJwtException.class)
+    protected ResponseEntity<ErrorResponse> handleCustomJwtException(CustomJwtException e) {
+        log.info("Handle CustomJwtException", e);
+
+        ErrorCode errorCode = e.getErrorCode();
+        String value = e.getValue();
+        int status = HttpStatus.UNAUTHORIZED.value();
         ErrorResponse errorResponse = new ErrorResponse(status, errorCode, value);
 
         return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(status));

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/BusinessException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/BusinessException.java
@@ -1,0 +1,21 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    // https://dukcode.github.io/spring/spring-custom-exception-and-exception-strategy/
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/CustomExpiredJwtException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/CustomExpiredJwtException.java
@@ -1,0 +1,12 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+
+public class CustomExpiredJwtException extends CustomJwtException {
+
+    private String value;
+
+    public CustomExpiredJwtException(String value) {
+        super(value, ErrorCode.EXPIRED_TOKEN);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/CustomJwtException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/CustomJwtException.java
@@ -1,0 +1,20 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends BusinessException {
+
+    private String value;
+
+    public CustomJwtException(String value) {
+        this(value, ErrorCode.TOKEN_COMMON);
+    }
+
+    public CustomJwtException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+        this.value = value;
+    }
+}
+

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/DuplicateEmailException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/DuplicateEmailException.java
@@ -1,0 +1,14 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class DuplicateEmailException extends DuplicateException {
+
+    private String email;
+
+    public DuplicateEmailException(String email) {
+        super(email, ErrorCode.DUPLICATE_EMAIL);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/DuplicateException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/DuplicateException.java
@@ -1,0 +1,20 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class DuplicateException extends BusinessException {
+
+    private String value;
+
+    public DuplicateException(String value) {
+        this(value, ErrorCode.DUPLICATE);
+        this.value = value;
+    }
+
+    public DuplicateException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+        this.value = value;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/EmailNotFoundException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/EmailNotFoundException.java
@@ -1,0 +1,12 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+
+public class EmailNotFoundException extends NotFoundException {
+
+    private String email;
+
+    public EmailNotFoundException(String email) {
+        super(email, ErrorCode.NOT_FOUND_EMAIL);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/EmailNotFoundException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/EmailNotFoundException.java
@@ -7,6 +7,6 @@ public class EmailNotFoundException extends NotFoundException {
     private String email;
 
     public EmailNotFoundException(String email) {
-        super(email, ErrorCode.NOT_FOUND_EMAIL);
+        super(email, ErrorCode.EMAIL_NOT_FOUND);
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/IncorrectJwtSubjectException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/IncorrectJwtSubjectException.java
@@ -1,0 +1,13 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+
+public class IncorrectJwtSubjectException extends CustomJwtException {
+
+    private String value;
+
+    public IncorrectJwtSubjectException(String value) {
+        super(value, ErrorCode.INCORRECT_TOKEN_SUBJECT);
+        this.value = value;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/IncorrectJwtSubjectException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/IncorrectJwtSubjectException.java
@@ -10,4 +10,8 @@ public class IncorrectJwtSubjectException extends CustomJwtException {
         super(value, ErrorCode.INCORRECT_TOKEN_SUBJECT);
         this.value = value;
     }
+
+    public IncorrectJwtSubjectException(Long value) {
+        this(Long.toString(value));
+    }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/InvalidAuthorizationHeaderException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/InvalidAuthorizationHeaderException.java
@@ -1,0 +1,17 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+
+public class InvalidAuthorizationHeaderException extends CustomJwtException {
+
+    private String value;
+
+    public InvalidAuthorizationHeaderException(String value) {
+        this(value, ErrorCode.INVALID_AUTHORIZATION_HEADER);
+    }
+
+    public InvalidAuthorizationHeaderException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+        this.value = value;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/NotFoundException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/NotFoundException.java
@@ -1,0 +1,20 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends BusinessException {
+
+    private String value;
+
+    public NotFoundException(String value) {
+        this(value, ErrorCode.NOT_FOUND);
+        this.value = value;
+    }
+
+    public NotFoundException(String value, ErrorCode errorCode) {
+        super(value, errorCode);
+        this.value = value;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/UserNotFoundException.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/business/UserNotFoundException.java
@@ -1,0 +1,16 @@
+package com.dogGetDrunk.meetjyou.common.exception.business;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode;
+
+public class UserNotFoundException extends NotFoundException {
+
+    private String userId;
+
+    public UserNotFoundException(Long userId) {
+        super(Long.toString(userId), ErrorCode.USER_NOT_FOUND);
+    }
+
+    public UserNotFoundException(String userId) {
+        super(userId, ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SwaggerConfig.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SwaggerConfig.java
@@ -1,44 +1,31 @@
 package com.dogGetDrunk.meetjyou.config;
 
-import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
-    // JWT를 사용하지 않는 경우
+    // JWT를 사용하는 경우
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
-                .info(apiInfo());
+                .info(new Info()
+                        .title("만나쥬 API")
+                        .version("1.0.0")
+                        .description("만나쥬 API 문서"))
+                .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("Bearer Authentication",
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")));
     }
 
-    private Info apiInfo() {
-        return new Info()
-                .title("API Test") // API의 제목
-                .description("만나쥬 API 문서") // API에 대한 설명
-                .version("1.0.0"); // API의 버전
-    }
-
-    // JWT를 사용하는 경우
-//    @Bean
-//    public OpenAPI openAPI() {
-//        String jwt = "JWT";
-//        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
-//        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
-//                .name(jwt)
-//                .type(SecurityScheme.Type.HTTP)
-//                .scheme("bearer")
-//                .bearerFormat("JWT")
-//        );
-//        return new OpenAPI()
-//                .components(new Components())
-//                .info(apiInfo())
-//                .addSecurityItem(securityRequirement)
-//                .components(components);
-//    }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
@@ -1,0 +1,53 @@
+package com.dogGetDrunk.meetjyou.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtManager {
+
+    private final SecretKey secretKey;
+    @Value("${jwt.issuer}")
+    private String issuer;
+    @Value("${jwt.access-expiration}")
+    private Long accessTokenExpiresIn;
+    @Value("${jwt.refresh-expiration}")
+    private Long refreshTokenExpiresIn;
+
+    public JwtManager(@Value("${jwt.secret-key}") String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public String generateAccessToken(String email) {
+        Date now = new Date();
+        return Jwts.builder()
+                .header()
+                    .type("JWT")
+                    .and()
+                .issuer(issuer)
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + accessTokenExpiresIn))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+        Date now = new Date();
+        return Jwts.builder()
+                .header()
+                    .type("JWT")
+                    .and()
+                .issuer(issuer)
+                .subject(email)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + refreshTokenExpiresIn))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
@@ -1,5 +1,6 @@
 package com.dogGetDrunk.meetjyou.jwt;
 
+import com.dogGetDrunk.meetjyou.common.exception.business.IncorrectJwtSubjectException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,8 +28,8 @@ public class JwtManager {
         Date now = new Date();
         return Jwts.builder()
                 .header()
-                    .type("JWT")
-                    .and()
+                .type("JWT")
+                .and()
                 .issuer(issuer)
                 .subject(email)
                 .issuedAt(now)
@@ -41,13 +42,26 @@ public class JwtManager {
         Date now = new Date();
         return Jwts.builder()
                 .header()
-                    .type("JWT")
-                    .and()
+                .type("JWT")
+                .and()
                 .issuer(issuer)
                 .subject(email)
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + refreshTokenExpiresIn))
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public void validateToken(String token, String email) {
+        String emailInToken = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+
+        if (!emailInToken.equals(email)) {
+            throw new IncorrectJwtSubjectException(email);
+        }
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/jwt/JwtManager.java
@@ -24,44 +24,44 @@ public class JwtManager {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    public String generateAccessToken(String email) {
+    public String generateAccessToken(Long userId) {
         Date now = new Date();
         return Jwts.builder()
                 .header()
                 .type("JWT")
                 .and()
                 .issuer(issuer)
-                .subject(email)
+                .subject(Long.toString(userId))
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + accessTokenExpiresIn))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public String generateRefreshToken(String email) {
+    public String generateRefreshToken(Long userId) {
         Date now = new Date();
         return Jwts.builder()
                 .header()
                 .type("JWT")
                 .and()
                 .issuer(issuer)
-                .subject(email)
+                .subject(Long.toString(userId))
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + refreshTokenExpiresIn))
                 .signWith(secretKey)
                 .compact();
     }
 
-    public void validateToken(String token, String email) {
-        String emailInToken = Jwts.parser()
+    public void validateToken(String token, Long userId) {
+        String userIdInToken = Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
                 .parseSignedClaims(token)
                 .getPayload()
                 .getSubject();
 
-        if (!emailInToken.equals(email)) {
-            throw new IncorrectJwtSubjectException(email);
+        if (!userIdInToken.equals(Long.toString(userId))) {
+            throw new IncorrectJwtSubjectException(userId);
         }
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Age.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Age.java
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum Age {
+    TEEN,
+    TWENTY,
+    THIRTY,
+    FORTY,
+    OLDER;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Diet.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Diet.java
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum Diet {
+    VEGETARIAN,
+    GLUTEN_FREE,
+    VEGAN,
+    SPECIFIC,
+    ANYTHING;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Etc.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Etc.java
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum Etc {
+    SMOKE,
+    NOT_SMOKE,
+    DRINK,
+    NOT_DRINK,
+    ANYTHING;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Gender.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Gender.java
@@ -1,0 +1,12 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum Gender {
+    // Male
+    M,
+
+    // Female
+    F,
+
+    // Other
+    O;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Personality.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Personality.java
@@ -1,0 +1,12 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum Personality {
+    INTROVERTED,
+    EXTROVERTED,
+    SOCIAL,
+    OPTIMISTIC,
+    FREE,
+    PRACTICAL,
+    CAREFUL,
+    BOLD;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/Preference.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/Preference.java
@@ -1,0 +1,25 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Preference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int type;
+    private String name;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/PreferenceRepository.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/PreferenceRepository.java
@@ -1,0 +1,7 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PreferenceRepository extends JpaRepository<Preference, Long> {
+    Preference findByName(String name);
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/TravelStyle.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/TravelStyle.java
@@ -1,0 +1,16 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+public enum TravelStyle {
+    ACTIVITY,
+    RELAX,
+    CULTURE,
+    FOOD,
+    SPORTS,
+    BUDGET,
+    LUXURY,
+    ADVENTURE,
+    NATURE,
+    URBAN,
+    ART,
+    SHOP;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreference.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreference.java
@@ -1,0 +1,37 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+import com.dogGetDrunk.meetjyou.user.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "UserPreference")
+public class UserPreference {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    @ManyToOne
+    private Preference preference;
+
+    public UserPreference(User user, Preference preference) {
+        this.user = user;
+        this.preference = preference;
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreferenceRepository.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreferenceRepository.java
@@ -1,0 +1,7 @@
+package com.dogGetDrunk.meetjyou.preference;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPreferenceRepository extends JpaRepository<UserPreference, Long> {
+
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/AuthProvider.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.dogGetDrunk.meetjyou.user;
+
+public enum AuthProvider {
+    KAKAO, GOOGLE, APPLE
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/Role.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/Role.java
@@ -1,0 +1,5 @@
+package com.dogGetDrunk.meetjyou.user;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/User.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/User.java
@@ -1,0 +1,50 @@
+package com.dogGetDrunk.meetjyou.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TINYINT(1) DEFAULT 1")
+    private boolean notified;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime lastLoginAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+    private String email;
+    private String nickname;
+    private int gender;
+    private int age;
+    private String bio;
+    private String imgUrl;
+    private String thumbImgUrl;
+    private AuthProvider authProvider;
+    private UserStatus status;
+    private Role role;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/User.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/User.java
@@ -39,8 +39,6 @@ public class User {
 
     private String email;
     private String nickname;
-    private int gender;
-    private int age;
     private String bio;
     private String imgUrl;
     private String thumbImgUrl;

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
@@ -15,7 +15,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -98,5 +100,21 @@ public class UserAuthController {
         TokenResponseDto tokenResponseDto = userService.refreshToken(refreshToken, requestDto.getEmail());
 
         return ResponseEntity.ok(tokenResponseDto);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "현재는 DELETE, 추후 PATCH로 변경될 수 있음.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 액세스 토큰입니다.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @DeleteMapping("/")
+    public void withdraw(@RequestHeader("Authorization") String authorizationHeader, @RequestParam String email) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            throw new InvalidAuthorizationHeaderException(authorizationHeader);
+        }
+
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        userService.withdrawUser(email, accessToken);
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
@@ -48,7 +48,7 @@ public class UserAuthController {
     @PostMapping("/registration")
     public ResponseEntity<TokenResponseDto> register(@RequestBody RegistrationRequestDto registrationRequestDto) {
         TokenResponseDto tokenResponseDto = userService.createUser(registrationRequestDto);
-        return ResponseEntity.created(URI.create("/" + registrationRequestDto.getEmail()))
+        return ResponseEntity.created(URI.create("/" + tokenResponseDto.getId()))
                 .body(tokenResponseDto);
     }
 
@@ -71,7 +71,7 @@ public class UserAuthController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "가입되지 않은 이메일입니다.",
+            @ApiResponse(responseCode = "404", description = "가입되지 않은 유저입니다.",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
     })
     @PostMapping("/login")
@@ -97,7 +97,7 @@ public class UserAuthController {
         }
 
         String refreshToken = authorizationHeader.substring("Bearer ".length());
-        TokenResponseDto tokenResponseDto = userService.refreshToken(refreshToken, requestDto.getEmail());
+        TokenResponseDto tokenResponseDto = userService.refreshToken(refreshToken, requestDto.getUserId());
 
         return ResponseEntity.ok(tokenResponseDto);
     }
@@ -108,13 +108,13 @@ public class UserAuthController {
             @ApiResponse(responseCode = "401", description = "유효하지 않은 액세스 토큰입니다.",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
     })
-    @DeleteMapping("/")
-    public void withdraw(@RequestHeader("Authorization") String authorizationHeader, @RequestParam String email) {
+    @DeleteMapping("/{userId}")
+    public void withdraw(@RequestHeader("Authorization") String authorizationHeader, @PathVariable Long userId) {
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
             throw new InvalidAuthorizationHeaderException(authorizationHeader);
         }
 
         String accessToken = authorizationHeader.substring("Bearer ".length());
-        userService.withdrawUser(email, accessToken);
+        userService.withdrawUser(userId, accessToken);
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.java
@@ -1,0 +1,77 @@
+package com.dogGetDrunk.meetjyou.user;
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse;
+import com.dogGetDrunk.meetjyou.user.dto.LoginRequestDto;
+import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequestDto;
+import com.dogGetDrunk.meetjyou.user.dto.TokenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Tag(name = "User authentication controller", description = "유저 인증 관련 API")
+public class UserAuthController {
+
+    private final UserService userService;
+
+    @Operation(summary = "유저 회원가입", description = "이메일로 회원 가입한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "회원가입이 완료되었습니다.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "이미 가입한 이메일입니다.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/registration")
+    public ResponseEntity<TokenResponseDto> register(@RequestBody RegistrationRequestDto registrationRequestDto) {
+        TokenResponseDto tokenResponseDto = userService.createUser(registrationRequestDto);
+        return ResponseEntity.created(URI.create("/" + registrationRequestDto.getEmail()))
+                .body(tokenResponseDto);
+    }
+
+
+    @Operation(summary = "유저 닉네임 중복 확인")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "complete",
+                    content = @Content(schema = @Schema(example = "{ \"isDuplicate\": true }")))
+    })
+    @GetMapping("/is-duplicate-nickname")
+    public ResponseEntity<Map<String, Boolean>> checkNicknameDuplication(@RequestParam String nickname) {
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("isDuplicate", userService.isDuplicateNickname(nickname));
+
+        return ResponseEntity.ok(response);
+    }
+
+
+    @Operation(summary = "유저 로그인", description = "이메일로 로그인한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "가입되지 않은 이메일입니다.",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+    })
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponseDto> login(@RequestBody LoginRequestDto loginRequestDto) {
+        TokenResponseDto tokenResponseDto = userService.login(loginRequestDto);
+        return ResponseEntity.ok(tokenResponseDto);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
@@ -1,0 +1,10 @@
+package com.dogGetDrunk.meetjyou.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
@@ -7,5 +7,4 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
-    void deleteByEmail(String email);
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
@@ -1,0 +1,67 @@
+package com.dogGetDrunk.meetjyou.user;
+
+import com.dogGetDrunk.meetjyou.common.exception.business.DuplicateEmailException;
+import com.dogGetDrunk.meetjyou.common.exception.business.EmailNotFoundException;
+import com.dogGetDrunk.meetjyou.jwt.JwtManager;
+import com.dogGetDrunk.meetjyou.user.dto.LoginRequestDto;
+import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequestDto;
+import com.dogGetDrunk.meetjyou.user.dto.TokenResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final JwtManager jwtManager;
+
+    public TokenResponseDto createUser(RegistrationRequestDto request) {
+        if (userRepository.existsByEmail(request.getEmail())) {
+            throw new DuplicateEmailException(request.getEmail());
+        }
+
+        User createdUser = userRepository.save(User.builder()
+                .email(request.getEmail())
+                .nickname(request.getNickname())
+                .gender(request.getGender())
+                .age(request.getAge())
+                .bio(request.getBio())
+                .authProvider(request.getAuthProvider())
+                .build());
+
+        String accessToken = jwtManager.generateAccessToken(request.getEmail());
+        String refreshToken = jwtManager.generateRefreshToken(request.getEmail());
+
+        return TokenResponseDto.builder()
+                .email(createdUser.getEmail())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+
+    public TokenResponseDto login(LoginRequestDto loginRequestDto) {
+        String email = loginRequestDto.getEmail();
+
+        if (!userRepository.existsByEmail(email)) {
+            throw new EmailNotFoundException(email);
+        }
+
+        String accessToken = jwtManager.generateAccessToken(email);
+        String refreshToken = jwtManager.generateRefreshToken(email);
+
+        return TokenResponseDto.builder()
+                .email(email)
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+
+    public boolean isDuplicateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
@@ -121,4 +121,17 @@ public class UserService {
                 .refreshToken(newRefreshToken)
                 .build();
     }
+
+    @Transactional
+    public void withdrawUser(String email, String accessToken) {
+        if (!userRepository.existsByEmail(email)) {
+            throw new EmailNotFoundException(email);
+        }
+
+        jwtManager.validateToken(accessToken, email);
+
+        log.info("유저 탈퇴 시작 (user email: {})", email);
+        userRepository.deleteByEmail(email);
+        log.info("유저 탈퇴 성공 (user email: {})", email);
+    }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
@@ -3,9 +3,16 @@ package com.dogGetDrunk.meetjyou.user;
 import com.dogGetDrunk.meetjyou.common.exception.business.DuplicateEmailException;
 import com.dogGetDrunk.meetjyou.common.exception.business.EmailNotFoundException;
 import com.dogGetDrunk.meetjyou.jwt.JwtManager;
+import com.dogGetDrunk.meetjyou.preference.Etc;
+import com.dogGetDrunk.meetjyou.preference.Personality;
+import com.dogGetDrunk.meetjyou.preference.PreferenceRepository;
+import com.dogGetDrunk.meetjyou.preference.TravelStyle;
+import com.dogGetDrunk.meetjyou.preference.UserPreference;
+import com.dogGetDrunk.meetjyou.preference.UserPreferenceRepository;
 import com.dogGetDrunk.meetjyou.user.dto.LoginRequestDto;
 import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequestDto;
 import com.dogGetDrunk.meetjyou.user.dto.TokenResponseDto;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,8 +23,11 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PreferenceRepository preferenceRepository;
+    private final UserPreferenceRepository userPreferenceRepository;
     private final JwtManager jwtManager;
 
+    @Transactional
     public TokenResponseDto createUser(RegistrationRequestDto request) {
         if (userRepository.existsByEmail(request.getEmail())) {
             throw new DuplicateEmailException(request.getEmail());
@@ -26,11 +36,44 @@ public class UserService {
         User createdUser = userRepository.save(User.builder()
                 .email(request.getEmail())
                 .nickname(request.getNickname())
-                .gender(request.getGender())
-                .age(request.getAge())
                 .bio(request.getBio())
                 .authProvider(request.getAuthProvider())
                 .build());
+
+        userPreferenceRepository.save(new UserPreference(
+                createdUser,
+                preferenceRepository.findByName(request.getGender().name())
+        ));
+        userPreferenceRepository.save(new UserPreference(
+                createdUser,
+                preferenceRepository.findByName(request.getAge().name())
+        ));
+
+        for (Personality p : request.getPersonality()) {
+            userPreferenceRepository.save(new UserPreference(
+                    createdUser,
+                    preferenceRepository.findByName(p.name())
+            ));
+        }
+
+        for (TravelStyle t : request.getTravelStyle()) {
+            userPreferenceRepository.save(new UserPreference(
+                    createdUser,
+                    preferenceRepository.findByName(t.name())
+            ));
+        }
+
+        userPreferenceRepository.save(new UserPreference(
+                createdUser,
+                preferenceRepository.findByName(request.getDiet().name())
+        ));
+
+        for (Etc e : request.getEtc()) {
+            userPreferenceRepository.save(new UserPreference(
+                    createdUser,
+                    preferenceRepository.findByName(e.name())
+            ));
+        }
 
         String accessToken = jwtManager.generateAccessToken(request.getEmail());
         String refreshToken = jwtManager.generateRefreshToken(request.getEmail());

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.java
@@ -107,4 +107,18 @@ public class UserService {
     public boolean isDuplicateNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
     }
+
+
+    public TokenResponseDto refreshToken(String refreshToken, String email) {
+        jwtManager.validateToken(refreshToken, email);
+
+        String newAccessToken = jwtManager.generateAccessToken(email);
+        String newRefreshToken = jwtManager.generateRefreshToken(email);
+
+        return TokenResponseDto.builder()
+                .email(email)
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserStatus.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserStatus.java
@@ -1,0 +1,5 @@
+package com.dogGetDrunk.meetjyou.user;
+
+public enum UserStatus {
+    NORMAL, DELETED
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequestDto.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class LoginRequestDto {
 
-    private String email;
+    private Long userId;
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+
+    private String email;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequestDto {
+
+    private String email;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequestDto.java
@@ -5,5 +5,5 @@ import lombok.Getter;
 @Getter
 public class RefreshTokenRequestDto {
 
-    private String email;
+    private Long userId;
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RegistrationRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RegistrationRequestDto.java
@@ -1,0 +1,15 @@
+package com.dogGetDrunk.meetjyou.user.dto;
+
+import com.dogGetDrunk.meetjyou.user.AuthProvider;
+import lombok.Getter;
+
+@Getter
+public class RegistrationRequestDto {
+
+    private String email;
+    private String nickname;
+    private int gender;
+    private int age;
+    private String bio;
+    private AuthProvider authProvider;
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RegistrationRequestDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RegistrationRequestDto.java
@@ -1,15 +1,27 @@
 package com.dogGetDrunk.meetjyou.user.dto;
 
+import com.dogGetDrunk.meetjyou.preference.Age;
+import com.dogGetDrunk.meetjyou.preference.Diet;
+import com.dogGetDrunk.meetjyou.preference.Etc;
+import com.dogGetDrunk.meetjyou.preference.Gender;
+import com.dogGetDrunk.meetjyou.preference.Personality;
+import com.dogGetDrunk.meetjyou.preference.TravelStyle;
 import com.dogGetDrunk.meetjyou.user.AuthProvider;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class RegistrationRequestDto {
 
     private String email;
     private String nickname;
-    private int gender;
-    private int age;
     private String bio;
+    private Gender gender;
+    private Age age;
+    private List<Personality> personality;
+    private List<TravelStyle> travelStyle;
+    private Diet diet;
+    private List<Etc> etc;
     private AuthProvider authProvider;
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponseDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponseDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public class TokenResponseDto {
 
-    private String email;
+    private Long id;
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponseDto.java
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponseDto.java
@@ -1,0 +1,13 @@
+package com.dogGetDrunk.meetjyou.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TokenResponseDto {
+
+    private String email;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,87 @@
+# preference - Gender
+INSERT INTO preference (type, name)
+VALUES (0, 'M');
+INSERT INTO preference (type, name)
+VALUES (0, 'F');
+INSERT INTO preference (type, name)
+VALUES (0, 'O');
+
+# preference - Age
+INSERT INTO preference (type, name)
+VALUES (1, 'TEEN');
+INSERT INTO preference (type, name)
+VALUES (1, 'TWENTY');
+INSERT INTO preference (type, name)
+VALUES (1, 'THIRTY');
+INSERT INTO preference (type, name)
+VALUES (1, 'FORTY');
+INSERT INTO preference (type, name)
+VALUES (1, 'OLDER');
+
+# preference - Personality
+INSERT INTO preference (type, name)
+VALUES (2, 'INTROVERTED');
+INSERT INTO preference (type, name)
+VALUES (2, 'EXTROVERTED');
+INSERT INTO preference (type, name)
+VALUES (2, 'SOCIAL');
+INSERT INTO preference (type, name)
+VALUES (2, 'OPTIMISTIC');
+INSERT INTO preference (type, name)
+VALUES (2, 'FREE');
+INSERT INTO preference (type, name)
+VALUES (2, 'PRACTICAL');
+INSERT INTO preference (type, name)
+VALUES (2, 'CAREFUL');
+INSERT INTO preference (type, name)
+VALUES (2, 'BOLD');
+
+# preference - Travel style
+INSERT INTO preference (type, name)
+VALUES (3, 'ACTIVITY');
+INSERT INTO preference (type, name)
+VALUES (3, 'RELAX');
+INSERT INTO preference (type, name)
+VALUES (3, 'CULTURE');
+INSERT INTO preference (type, name)
+VALUES (3, 'FOOD');
+INSERT INTO preference (type, name)
+VALUES (3, 'SPORTS');
+INSERT INTO preference (type, name)
+VALUES (3, 'BUDGET');
+INSERT INTO preference (type, name)
+VALUES (3, 'LUXURY');
+INSERT INTO preference (type, name)
+VALUES (3, 'ADVENTURE');
+INSERT INTO preference (type, name)
+VALUES (3, 'NATURE');
+INSERT INTO preference (type, name)
+VALUES (3, 'URBAN');
+INSERT INTO preference (type, name)
+VALUES (3, 'ART');
+INSERT INTO preference (type, name)
+VALUES (3, 'SHOP');
+
+# preference - Diet
+INSERT INTO preference (type, name)
+VALUES (4, 'VEGETARIAN');
+INSERT INTO preference (type, name)
+VALUES (4, 'GLUTEN_FREE');
+INSERT INTO preference (type, name)
+VALUES (4, 'VEGAN');
+INSERT INTO preference (type, name)
+VALUES (4, 'SPECIFIC');
+INSERT INTO preference (type, name)
+VALUES (4, 'ANYTHING');
+
+# preference - Etc
+INSERT INTO preference (type, name)
+VALUES (5, 'SMOKE');
+INSERT INTO preference (type, name)
+VALUES (5, 'NOT_SMOKE');
+INSERT INTO preference (type, name)
+VALUES (5, 'DRINK');
+INSERT INTO preference (type, name)
+VALUES (5, 'NOT_DRINK');
+INSERT INTO preference (type, name)
+VALUES (5, 'ANYTHING');

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -157,52 +157,52 @@ CREATE TABLE user_party
 );
 
 ALTER TABLE post
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);
 
 ALTER TABLE post
-    ADD FOREIGN KEY (party_id) REFERENCES Party (id);
+    ADD FOREIGN KEY (party_id) REFERENCES party (id);
 
 ALTER TABLE post
-    ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
+    ADD FOREIGN KEY (plan_id) REFERENCES plan (id);
 
 ALTER TABLE party
-    ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
+    ADD FOREIGN KEY (plan_id) REFERENCES plan (id);
 
 ALTER TABLE chat_message
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);
 
 ALTER TABLE chat_message
-    ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
+    ADD FOREIGN KEY (plan_id) REFERENCES plan (id);
 
 ALTER TABLE plan
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);
 
 ALTER TABLE marker
-    ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
+    ADD FOREIGN KEY (plan_id) REFERENCES plan (id);
 
 ALTER TABLE notification
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);
 
 ALTER TABLE user_preference
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE;
 
 ALTER TABLE user_preference
-    ADD FOREIGN KEY (preference_id) REFERENCES Preference (id);
+    ADD FOREIGN KEY (preference_id) REFERENCES preference (id);
 
 ALTER TABLE comp_preference
-    ADD FOREIGN KEY (post_id) REFERENCES Post (id);
+    ADD FOREIGN KEY (post_id) REFERENCES post (id);
 
 ALTER TABLE comp_preference
-    ADD FOREIGN KEY (preference_id) REFERENCES Preference (id);
+    ADD FOREIGN KEY (preference_id) REFERENCES preference (id);
 
 ALTER TABLE party_application
-    ADD FOREIGN KEY (party_id) REFERENCES Party (id);
+    ADD FOREIGN KEY (party_id) REFERENCES party (id);
 
 ALTER TABLE party_application
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);
 
 ALTER TABLE user_party
-    ADD FOREIGN KEY (party_id) REFERENCES Party (id);
+    ADD FOREIGN KEY (party_id) REFERENCES party (id);
 
 ALTER TABLE user_party
-    ADD FOREIGN KEY (user_id) REFERENCES User (id);
+    ADD FOREIGN KEY (user_id) REFERENCES user (id);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,27 +1,25 @@
 SET foreign_key_checks = 0; # FK 체크를 무시함으로써 테이블을 바로 삭제할 수 있음
-DROP TABLE IF EXISTS User;
-DROP TABLE IF EXISTS Post;
-DROP TABLE IF EXISTS Party;
-DROP TABLE IF EXISTS ChatMessage;
-DROP TABLE IF EXISTS Plan;
-DROP TABLE IF EXISTS Marker;
-DROP TABLE IF EXISTS Notification;
-DROP TABLE IF EXISTS Notice;
-DROP TABLE IF EXISTS Preference;
-DROP TABLE IF EXISTS UserPreference;
-DROP TABLE IF EXISTS CompPreference;
-DROP TABLE IF EXISTS PartyApplication;
-DROP TABLE IF EXISTS UserParty;
+DROP TABLE IF EXISTS user;
+DROP TABLE IF EXISTS post;
+DROP TABLE IF EXISTS party;
+DROP TABLE IF EXISTS chat_message;
+DROP TABLE IF EXISTS plan;
+DROP TABLE IF EXISTS marker;
+DROP TABLE IF EXISTS notification;
+DROP TABLE IF EXISTS notice;
+DROP TABLE IF EXISTS preference;
+DROP TABLE IF EXISTS user_preference;
+DROP TABLE IF EXISTS comp_preference;
+DROP TABLE IF EXISTS party_application;
+DROP TABLE IF EXISTS user_party;
 SET foreign_key_checks = 1; # FK 체크 재활성화
 
 
-CREATE TABLE User
+CREATE TABLE user
 (
     id            INT AUTO_INCREMENT PRIMARY KEY,
     email         VARCHAR(500) NOT NULL UNIQUE,
     nickname      VARCHAR(20)  NOT NULL UNIQUE,
-    gender        TINYINT      NOT NULL,
-    age           TINYINT      NOT NULL,
     created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     bio           VARCHAR(500),
     img_url       VARCHAR(500),
@@ -34,7 +32,7 @@ CREATE TABLE User
     role          TINYINT               DEFAULT 0
 );
 
-CREATE TABLE Post
+CREATE TABLE post
 (
     id             INT AUTO_INCREMENT PRIMARY KEY,
     title          VARCHAR(50)  NOT NULL,
@@ -49,7 +47,7 @@ CREATE TABLE Post
     plan_id        INT
 );
 
-CREATE TABLE Party
+CREATE TABLE party
 (
     id             INT AUTO_INCREMENT PRIMARY KEY,
     itin_start     TIMESTAMP   NOT NULL,
@@ -65,7 +63,7 @@ CREATE TABLE Party
     plan_id        INT
 );
 
-CREATE TABLE ChatMessage
+CREATE TABLE chat_message
 (
     id         INT AUTO_INCREMENT PRIMARY KEY,
     body       VARCHAR(1000) NOT NULL,
@@ -74,7 +72,7 @@ CREATE TABLE ChatMessage
     plan_id    INT
 );
 
-CREATE TABLE Plan
+CREATE TABLE plan
 (
     id          INT AUTO_INCREMENT PRIMARY KEY,
     itin_start  TIMESTAMP       NOT NULL,
@@ -86,7 +84,7 @@ CREATE TABLE Plan
     user_id     INT
 );
 
-CREATE TABLE Marker
+CREATE TABLE marker
 (
     id      INT AUTO_INCREMENT PRIMARY KEY,
     lat     DECIMAL(13, 10) NOT NULL,
@@ -97,7 +95,7 @@ CREATE TABLE Marker
     plan_id INT
 );
 
-CREATE TABLE Notification
+CREATE TABLE notification
 (
     id           INT AUTO_INCREMENT PRIMARY KEY,
     type         TINYINT      NOT NULL,
@@ -108,7 +106,7 @@ CREATE TABLE Notification
     user_id      INT
 );
 
-CREATE TABLE Notice
+CREATE TABLE notice
 (
     id             INT AUTO_INCREMENT PRIMARY KEY,
     title          VARCHAR(50)   NOT NULL,
@@ -117,28 +115,28 @@ CREATE TABLE Notice
     last_edited_at TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE Preference
+CREATE TABLE preference
 (
     id   INT AUTO_INCREMENT PRIMARY KEY,
     type TINYINT     NOT NULL,
     name VARCHAR(20) NOT NULL
 );
 
-CREATE TABLE UserPreference
+CREATE TABLE user_preference
 (
     id            INT AUTO_INCREMENT PRIMARY KEY,
     user_id       INT,
     preference_id INT
 );
 
-CREATE TABLE CompPreference
+CREATE TABLE comp_preference
 (
     id            INT AUTO_INCREMENT PRIMARY KEY,
     post_id       INT,
     preference_id INT
 );
 
-CREATE TABLE PartyApplication
+CREATE TABLE party_application
 (
     id         INT AUTO_INCREMENT PRIMARY KEY,
     title      VARCHAR(50) NOT NULL,
@@ -149,7 +147,7 @@ CREATE TABLE PartyApplication
     user_id    INT
 );
 
-CREATE TABLE UserParty
+CREATE TABLE user_party
 (
     id        INT AUTO_INCREMENT PRIMARY KEY,
     role      TINYINT   NOT NULL,
@@ -158,53 +156,53 @@ CREATE TABLE UserParty
     user_id   INT
 );
 
-ALTER TABLE Post
+ALTER TABLE post
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE Post
+ALTER TABLE post
     ADD FOREIGN KEY (party_id) REFERENCES Party (id);
 
-ALTER TABLE Post
+ALTER TABLE post
     ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
 
-ALTER TABLE Party
+ALTER TABLE party
     ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
 
-ALTER TABLE ChatMessage
+ALTER TABLE chat_message
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE ChatMessage
+ALTER TABLE chat_message
     ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
 
-ALTER TABLE Plan
+ALTER TABLE plan
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE Marker
+ALTER TABLE marker
     ADD FOREIGN KEY (plan_id) REFERENCES Plan (id);
 
-ALTER TABLE Notification
+ALTER TABLE notification
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE UserPreference
+ALTER TABLE user_preference
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE UserPreference
+ALTER TABLE user_preference
     ADD FOREIGN KEY (preference_id) REFERENCES Preference (id);
 
-ALTER TABLE CompPreference
+ALTER TABLE comp_preference
     ADD FOREIGN KEY (post_id) REFERENCES Post (id);
 
-ALTER TABLE CompPreference
+ALTER TABLE comp_preference
     ADD FOREIGN KEY (preference_id) REFERENCES Preference (id);
 
-ALTER TABLE PartyApplication
+ALTER TABLE party_application
     ADD FOREIGN KEY (party_id) REFERENCES Party (id);
 
-ALTER TABLE PartyApplication
+ALTER TABLE party_application
     ADD FOREIGN KEY (user_id) REFERENCES User (id);
 
-ALTER TABLE UserParty
+ALTER TABLE user_party
     ADD FOREIGN KEY (party_id) REFERENCES Party (id);
 
-ALTER TABLE UserParty
+ALTER TABLE user_party
     ADD FOREIGN KEY (user_id) REFERENCES User (id);


### PR DESCRIPTION
회원 탈퇴 기능 구현 중 프론트에서 email을 넘겨받을 경우 발생하는 이슈를 인지함.

현재 데이터베이스의 유저 테이블에는 PK가 id로 잡혀있음. (auto increment)
이 상태에서 email을 통해 데이터베이스에 삭제 요청을 날리면, PK인 id를 email로 조회한 다음 id로 레코드를 삭제함.
따라서 SELECT 쿼리가 추가적으로 발생함.

가능한 해결 방안:

1. 데이터베이스 유저 테이블의 PK를 email로 변경한다.
- email이 변경 가능한지 체크해봐야 함. 현재 불가능하더라도 추후 소셜 로그인 제공자(카카오, 구글, 애플)의 정책에 따른 리스크가 있음.

2. 탈퇴 요청 시 email이 아닌 userId를 전달받는다.
- 이를 적용하면 통일성을 위해 거의 모든 API에서 email이 아닌 userId로 통신해야 함. 

3. 해결하지 않는다. (현상 유지)
- 이런 현상이 얼마나 발생할지, 그에 따른 부하가 어느 정도일지 계산해보고 판단.