### PR TITLE
refactor: DTO 내의 uuid 자료형 String -> UUID로 통일

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/party/dto/CreatePartyRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/dto/CreatePartyRequest.kt
@@ -1,7 +1,6 @@
 package com.dogGetDrunk.meetjyou.party.dto
 
 import com.dogGetDrunk.meetjyou.post.Post
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 import java.util.UUID
 
@@ -12,19 +11,9 @@ data class CreatePartyRequest(
     val joined: Int,
     val capacity: Int,
     val name: String,
-
-    @field:JsonProperty("post_uuid")
-    val postUuidString: String,
-
-    @field:JsonProperty("plan_uuid")
-    val planUuidString: String?,
+    val postUuid: UUID,
+    val planUuid: UUID?,
 ) {
-    val postUuid: UUID
-        get() = UUID.fromString(postUuidString)
-
-    val planUuid: UUID?
-        get() = planUuidString?.let { UUID.fromString(it) }
-
     companion object {
         fun from(post: Post): CreatePartyRequest {
             return CreatePartyRequest(
@@ -34,8 +23,8 @@ data class CreatePartyRequest(
                 capacity = post.capacity,
                 joined = 1,
                 name = post.title,
-                postUuidString = post.uuid.toString(),
-                planUuidString = post.plan?.uuid.toString(),
+                postUuid = post.uuid,
+                planUuid = post.plan?.uuid,
             )
         }
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/dto/CreatePartyResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/dto/CreatePartyResponse.kt
@@ -2,16 +2,17 @@ package com.dogGetDrunk.meetjyou.party.dto
 
 import com.dogGetDrunk.meetjyou.party.Party
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CreatePartyResponse(
-    val uuid: String,
+    val uuid: UUID,
     val name: String,
     val location: String,
     val createdAt: LocalDateTime
 ) {
     companion object {
         fun of(party: Party) = CreatePartyResponse(
-            uuid = party.uuid.toString(),
+            uuid = party.uuid,
             name = party.name,
             location = party.location,
             createdAt = party.createdAt

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/dto/GetPartyResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/dto/GetPartyResponse.kt
@@ -3,9 +3,10 @@ package com.dogGetDrunk.meetjyou.party.dto
 import com.dogGetDrunk.meetjyou.party.Party
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GetPartyResponse(
-    val uuid: String,
+    val uuid: UUID,
     val itinStart: LocalDate,
     val itinFinish: LocalDate,
     val location: String,
@@ -14,12 +15,12 @@ data class GetPartyResponse(
     val name: String,
     val createdAt: LocalDateTime,
     val lastEditedAt: LocalDateTime,
-    val planUuid: String?
+    val planUuid: UUID?
 ) {
     companion object {
         fun of(party: Party): GetPartyResponse {
             return GetPartyResponse(
-                uuid = party.uuid.toString(),
+                uuid = party.uuid,
                 itinStart = party.itinStart,
                 itinFinish = party.itinFinish,
                 location = party.location,
@@ -28,7 +29,7 @@ data class GetPartyResponse(
                 name = party.name,
                 createdAt = party.createdAt,
                 lastEditedAt = party.lastEditedAt,
-                planUuid = party.plan?.uuid.toString(),
+                planUuid = party.plan?.uuid,
             )
         }
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/dto/UpdatePartyRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/dto/UpdatePartyRequest.kt
@@ -1,6 +1,5 @@
 package com.dogGetDrunk.meetjyou.party.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 data class UpdatePartyRequest(
@@ -8,16 +7,8 @@ data class UpdatePartyRequest(
     val location: String,
     val joined: Int,
     val capacity: Int,
-
-    @field:JsonProperty("itin_start")
     val itinStart: LocalDate,
-
-    @field:JsonProperty("itin_finish")
     val itinFinish: LocalDate,
-
-    @field:JsonProperty("img_url")
     val imgUrl: String,
-
-    @field:JsonProperty("thumb_img_url")
     val thumbImgUrl: String,
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/dto/UpdatePartyResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/dto/UpdatePartyResponse.kt
@@ -2,17 +2,18 @@ package com.dogGetDrunk.meetjyou.party.dto
 
 import com.dogGetDrunk.meetjyou.party.Party
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class UpdatePartyResponse(
-    val uuid: String,
+    val uuid: UUID,
     val name: String,
     val lastEditedAt: LocalDateTime
 ) {
     companion object {
         fun of(party: Party) = UpdatePartyResponse(
-            uuid = party.uuid.toString(),
+            uuid = party.uuid,
             name = party.name,
-            lastEditedAt = party.lastEditedAt!!
+            lastEditedAt = party.lastEditedAt,
         )
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/CreatePlanResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/CreatePlanResponse.kt
@@ -2,27 +2,28 @@ package com.dogGetDrunk.meetjyou.plan.dto
 
 import com.dogGetDrunk.meetjyou.plan.Plan
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CreatePlanResponse(
-    val uuid: String,
+    val uuid: UUID,
     val itinStart: LocalDateTime,
     val itinFinish: LocalDateTime,
     val destination: String,
     val centerLat: Double,
     val centerLng: Double,
     val memo: String?,
-    val userUuid: String
+    val userUuid: UUID
 ) {
     companion object {
         fun of(plan: Plan) = CreatePlanResponse(
-            uuid = plan.uuid.toString(),
+            uuid = plan.uuid,
             itinStart = plan.itinStart,
             itinFinish = plan.itinFinish,
             destination = plan.location,
             centerLat = plan.centerLat,
             centerLng = plan.centerLng,
             memo = plan.memo,
-            userUuid = plan.owner.uuid.toString()
+            userUuid = plan.owner.uuid,
         )
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/GetPlanResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/GetPlanResponse.kt
@@ -2,27 +2,28 @@ package com.dogGetDrunk.meetjyou.plan.dto
 
 import com.dogGetDrunk.meetjyou.plan.Plan
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GetPlanResponse(
-    val uuid: String,
+    val uuid: UUID,
     val itinStart: LocalDateTime,
     val itinFinish: LocalDateTime,
     val destination: String,
     val centerLat: Double,
     val centerLng: Double,
     val memo: String?,
-    val userUuid: String
+    val userUuid: UUID
 ) {
     companion object {
         fun of(plan: Plan) = GetPlanResponse(
-            uuid = plan.uuid.toString(),
+            uuid = plan.uuid,
             itinStart = plan.itinStart,
             itinFinish = plan.itinFinish,
             destination = plan.location,
             centerLat = plan.centerLat,
             centerLng = plan.centerLng,
             memo = plan.memo,
-            userUuid = plan.owner.uuid.toString()
+            userUuid = plan.owner.uuid,
         )
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanRequest.kt
@@ -3,7 +3,6 @@ package com.dogGetDrunk.meetjyou.plan.dto
 import java.time.LocalDateTime
 
 data class UpdatePlanRequest(
-
     val itinStart: LocalDateTime,
     val itinFinish: LocalDateTime,
     val location: String,

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanResponse.kt
@@ -2,27 +2,28 @@ package com.dogGetDrunk.meetjyou.plan.dto
 
 import com.dogGetDrunk.meetjyou.plan.Plan
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class UpdatePlanResponse(
-    val uuid: String,
+    val uuid: UUID,
     val itinStart: LocalDateTime,
     val itinFinish: LocalDateTime,
     val destination: String,
     val centerLat: Double,
     val centerLng: Double,
     val memo: String?,
-    val userUuid: String
+    val userUuid: UUID
 ) {
     companion object {
         fun of(plan: Plan) = UpdatePlanResponse(
-            uuid = plan.uuid.toString(),
+            uuid = plan.uuid,
             itinStart = plan.itinStart,
             itinFinish = plan.itinFinish,
             destination = plan.location,
             centerLat = plan.centerLat,
             centerLng = plan.centerLng,
             memo = plan.memo,
-            userUuid = plan.owner.uuid.toString()
+            userUuid = plan.owner.uuid,
         )
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
@@ -149,7 +149,7 @@ class PostService(
             CreatePostRequest(
                 title = request.title,
                 content = request.content,
-                authorUuidString = request.authorUuid.toString(),
+                authorUuid = request.authorUuid,
                 isInstant = request.isInstant,
                 itinStart = request.itinStart,
                 itinFinish = request.itinFinish,
@@ -162,7 +162,7 @@ class PostService(
                 compTravelStyles = request.compTravelStyles,
                 compDiet = request.compDiet,
                 compEtc = request.compEtc,
-                planUuidString = request.planUuid?.toString(),
+                planUuid = request.planUuid,
             )
         )
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/CreatePostRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/CreatePostRequest.kt
@@ -5,7 +5,6 @@ import com.dogGetDrunk.meetjyou.preference.Diet
 import com.dogGetDrunk.meetjyou.preference.Etc
 import com.dogGetDrunk.meetjyou.preference.Gender
 import com.dogGetDrunk.meetjyou.preference.Personality
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 import java.util.UUID
 
@@ -24,12 +23,6 @@ data class CreatePostRequest(
     val compTravelStyles: List<Personality>,
     val compDiet: List<Diet>,
     val compEtc: List<Etc>,
-    @field:JsonProperty("author_uuid") private val authorUuidString: String,
-    @field:JsonProperty("plan_uuid") private val planUuidString: String?,
-) {
-    val authorUuid: UUID
-        get() = UUID.fromString(authorUuidString)
-
-    val planUuid: UUID?
-        get() = planUuidString?.let { UUID.fromString(it) }
-}
+    val authorUuid: UUID,
+    val planUuid: UUID?,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/CreatePostResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/CreatePostResponse.kt
@@ -5,15 +5,16 @@ import com.dogGetDrunk.meetjyou.preference.CompPreference
 import com.dogGetDrunk.meetjyou.preference.PreferenceType
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CreatePostResponse(
-    val uuid: String,
+    val uuid: UUID,
     val title: String,
     val content: String,
     val createdAt: LocalDateTime,
     val lastEditedAt: LocalDateTime,
     val postStatus: Int,
-    val authorUuid: String,
+    val authorUuid: UUID,
     val isInstant: Boolean,
     val itinStart: LocalDate,
     val itinFinish: LocalDate,
@@ -26,25 +27,25 @@ data class CreatePostResponse(
     val compTravelStyles: List<String>,
     val compDiet: List<String>,
     val compEtc: List<String>,
-    val planUuid: String?,
+    val planUuid: UUID?,
 ) {
     companion object {
         fun of(post: Post, compPreferences: List<CompPreference>): CreatePostResponse {
             return CreatePostResponse(
-                uuid = post.uuid.toString(),
+                uuid = post.uuid,
                 title = post.title,
                 content = post.content,
                 createdAt = post.createdAt,
                 lastEditedAt = post.lastEditedAt,
                 postStatus = post.postStatus,
-                authorUuid = post.author.uuid.toString(),
+                authorUuid = post.author.uuid,
                 isInstant = post.isInstant,
                 itinStart = post.itinStart,
                 itinFinish = post.itinFinish,
                 location = post.location,
                 capacity = post.capacity,
                 joined = post.joined,
-                planUuid = post.plan?.uuid?.toString(),
+                planUuid = post.plan?.uuid,
                 compGender = compPreferences.find { it.preference.type == PreferenceType.GENDER }?.preference?.name.orEmpty(),
                 compAge = compPreferences.find { it.preference.type == PreferenceType.AGE }?.preference?.name.orEmpty(),
                 compPersonalities = compPreferences.filter { it.preference.type == PreferenceType.PERSONALITY }

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/GetPostResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/GetPostResponse.kt
@@ -5,16 +5,17 @@ import com.dogGetDrunk.meetjyou.preference.CompPreference
 import com.dogGetDrunk.meetjyou.preference.PreferenceType
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class GetPostResponse(
-    val uuid: String,
+    val uuid: UUID,
     val title: String,
     val content: String,
     val createdAt: LocalDateTime,
     val lastEditedAt: LocalDateTime,
     val postStatus: Int,
     val views: Int,
-    val authorUuid: String,
+    val authorUuid: UUID,
     val isInstant: Boolean,
     val itinStart: LocalDate,
     val itinFinish: LocalDate,
@@ -27,26 +28,26 @@ data class GetPostResponse(
     val compTravelStyles: List<String>,
     val compDiet: List<String>,
     val compEtc: List<String>,
-    val planUuid: String?,
+    val planUuid: UUID?,
 ) {
     companion object {
         fun of(post: Post, compPreferences: List<CompPreference>): GetPostResponse {
             return GetPostResponse(
-                uuid = post.uuid.toString(),
+                uuid = post.uuid,
                 title = post.title,
                 content = post.content,
                 createdAt = post.createdAt,
                 lastEditedAt = post.lastEditedAt,
                 postStatus = post.postStatus,
                 views = post.views,
-                authorUuid = post.author.uuid.toString(),
+                authorUuid = post.author.uuid,
                 isInstant = post.isInstant,
                 itinStart = post.itinStart,
                 itinFinish = post.itinFinish,
                 location = post.location,
                 capacity = post.capacity,
                 joined = post.joined,
-                planUuid = post.plan?.uuid?.toString(),
+                planUuid = post.plan?.uuid,
                 compGender = compPreferences.find { it.preference.type == PreferenceType.GENDER }?.preference?.name,
                 compAge = compPreferences.find { it.preference.type == PreferenceType.AGE }?.preference?.name,
                 compPersonalities = compPreferences.filter { it.preference.type == PreferenceType.PERSONALITY }

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostRequest.kt
@@ -5,7 +5,6 @@ import com.dogGetDrunk.meetjyou.preference.Diet
 import com.dogGetDrunk.meetjyou.preference.Etc
 import com.dogGetDrunk.meetjyou.preference.Gender
 import com.dogGetDrunk.meetjyou.preference.Personality
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 import java.util.UUID
 
@@ -24,12 +23,6 @@ data class UpdatePostRequest(
     val compTravelStyles: List<Personality>,
     val compDiet: List<Diet>,
     val compEtc: List<Etc>,
-    @field:JsonProperty("author_uuid") private val authorUuidString: String,
-    @field:JsonProperty("plan_uuid") private val planUuidString: String?,
-) {
-    val authorUuid: UUID
-        get() = UUID.fromString(authorUuidString)
-
-    val planUuid: UUID?
-        get() = planUuidString?.let { UUID.fromString(it) }
-}
+    val authorUuid: UUID,
+    val planUuid: UUID?,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostResponse.kt
@@ -5,15 +5,16 @@ import com.dogGetDrunk.meetjyou.preference.CompPreference
 import com.dogGetDrunk.meetjyou.preference.PreferenceType
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class UpdatePostResponse(
-    val uuid: String,
+    val uuid: UUID,
     val title: String,
     val content: String,
     val createdAt: LocalDateTime,
     val lastEditedAt: LocalDateTime,
     val postStatus: Int,
-    val authorUuid: String,
+    val authorUuid: UUID,
     val isInstant: Boolean,
     val itinStart: LocalDate,
     val itinFinish: LocalDate,
@@ -26,25 +27,25 @@ data class UpdatePostResponse(
     val compTravelStyles: List<String>,
     val compDiet: List<String>,
     val compEtc: List<String>,
-    val planUuid: String?
+    val planUuid: UUID?
 ) {
     companion object {
         fun of(post: Post, compPreferences: List<CompPreference>): UpdatePostResponse {
             return UpdatePostResponse(
-                uuid = post.uuid.toString(),
+                uuid = post.uuid,
                 title = post.title,
                 content = post.content,
                 createdAt = post.createdAt,
                 lastEditedAt = post.lastEditedAt,
                 postStatus = post.postStatus,
-                authorUuid = post.author.uuid.toString(),
+                authorUuid = post.author.uuid,
                 isInstant = post.isInstant,
                 itinStart = post.itinStart,
                 itinFinish = post.itinFinish,
                 location = post.location,
                 capacity = post.capacity,
                 joined = post.joined,
-                planUuid = post.plan?.uuid?.toString(),
+                planUuid = post.plan?.uuid,
                 compGender = compPreferences.find { it.preference.type == PreferenceType.GENDER }?.preference?.name.orEmpty(),
                 compAge = compPreferences.find { it.preference.type == PreferenceType.AGE }?.preference?.name.orEmpty(),
                 compPersonalities = compPreferences.filter { it.preference.type == PreferenceType.PERSONALITY }.map { it.preference.name },

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -52,7 +52,7 @@ class UserService(
         val accessToken = jwtManager.generateAccessToken(createdUser.uuid)
         val refreshToken = jwtManager.generateRefreshToken(createdUser.uuid)
 
-        return TokenResponse(createdUser.uuid.toString(), accessToken, refreshToken)
+        return TokenResponse(createdUser.uuid, accessToken, refreshToken)
     }
 
     fun login(request: LoginRequest): TokenResponse {
@@ -64,7 +64,7 @@ class UserService(
         val accessToken = jwtManager.generateAccessToken(request.uuid)
         val refreshToken = jwtManager.generateRefreshToken(request.uuid)
 
-        return TokenResponse(request.uuid.toString(), accessToken, refreshToken)
+        return TokenResponse(request.uuid, accessToken, refreshToken)
     }
 
     fun isDuplicateNickname(nickname: String): Boolean {
@@ -77,7 +77,7 @@ class UserService(
         val newAccessToken = jwtManager.generateAccessToken(uuid)
         val newRefreshToken = jwtManager.generateRefreshToken(uuid)
 
-        return TokenResponse(uuid.toString(), newAccessToken, newRefreshToken)
+        return TokenResponse(uuid, newAccessToken, newRefreshToken)
     }
 
     @Transactional
@@ -121,7 +121,7 @@ class UserService(
             ?: throw UserNotFoundException(uuid)
 
         return BasicUserResponse(
-            uuid = user.uuid.toString(),
+            uuid = user.uuid,
             nickname = user.nickname,
             bio = user.bio,
             gender = getPreferenceName(user.id, 0),
@@ -138,7 +138,7 @@ class UserService(
     fun getAllUsersProfile(): List<BasicUserResponse> {
         return userRepository.findAll().map { user ->
             BasicUserResponse(
-                uuid = user.uuid.toString(),
+                uuid = user.uuid,
                 nickname = user.nickname,
                 bio = user.bio,
                 gender = getPreferenceName(user.id, 0),

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/BasicUserResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/BasicUserResponse.kt
@@ -1,9 +1,10 @@
 package com.dogGetDrunk.meetjyou.user.dto
 
 import com.dogGetDrunk.meetjyou.user.AuthProvider
+import java.util.UUID
 
 data class BasicUserResponse(
-    val uuid: String,
+    val uuid: UUID,
     val nickname: String,
     val bio: String?,
     val gender: String,

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/LoginRequest.kt
@@ -1,12 +1,8 @@
 package com.dogGetDrunk.meetjyou.user.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 data class LoginRequest(
-    @field:JsonProperty("uuid") private val uuidString: String,
+    val uuid: UUID,
     val email: String,
-) {
-    val uuid: UUID
-        get() = UUID.fromString(uuidString)
-}
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/RefreshTokenRequest.kt
@@ -1,11 +1,7 @@
 package com.dogGetDrunk.meetjyou.user.dto
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import java.util.UUID
 
 data class RefreshTokenRequest(
-    @field:JsonProperty("uuid") private val uuidString: String
-) {
     val uuid: UUID
-        get() = UUID.fromString(uuidString)
-}
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponse.kt
@@ -1,7 +1,9 @@
 package com.dogGetDrunk.meetjyou.user.dto
 
+import java.util.UUID
+
 data class TokenResponse(
-    val uuid: String,
+    val uuid: UUID,
     val accessToken: String,
     val refreshToken: String
 )


### PR DESCRIPTION
request & response DTO 내의 모든 uuid 관련 필드는 String이 아닌 UUID로 관리되도록 변경함