### PR TITLE
fix: 유저 기본 정보 조회 중 발생한 IncorrectResultSizeDataAccessException 해결

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/util/SecurityUtil.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/util/SecurityUtil.kt
@@ -20,7 +20,7 @@ object SecurityUtil {
     private fun getPrincipal(): CustomUserPrincipal {
         val authentication = SecurityContextHolder.getContext().authentication
             ?: throw UnauthenticatedException("current-user")
-ㅁ
+
         return authentication.principal as? CustomUserPrincipal
             ?: throw UnauthenticatedException("current-user")
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -145,7 +145,7 @@ class UserService(
             age = getPreferenceName(user.id, PreferenceType.AGE),
             personalities = getPreferenceNames(user.id, PreferenceType.PERSONALITY),
             travelStyles = getPreferenceNames(user.id, PreferenceType.TRAVEL_STYLE),
-            diet = getPreferenceName(user.id, PreferenceType.DIET),
+            diet = getPreferenceNames(user.id, PreferenceType.DIET),
             etc = getPreferenceNames(user.id, PreferenceType.ETC),
             authProvider = user.authProvider,
             marketingConsented = user.marketingConsented,

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/BasicUserResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/BasicUserResponse.kt
@@ -12,7 +12,7 @@ data class BasicUserResponse(
     val age: String,
     val personalities: List<String>,
     val travelStyles: List<String>,
-    val diet: String,
+    val diet: List<String>,
     val etc: List<String>,
     val authProvider: AuthProvider,
     val marketingConsented: Boolean,


### PR DESCRIPTION
회원 가입 정책 상 Diet 필드는 복수 개의 레코드 발생 가능. 그러나 유저 정보 반환 시 1개만 조회하는 버그 존재, 에러가 발생함. 복수 개 조회 후 복수 개 반환하는 것으로 수정.