### PR TITLE
feat: API 버전 관리 구조 도입 (PathMatchConfigurer + @RestControllerV1)

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadController.kt
@@ -3,23 +3,25 @@ package com.dogGetDrunk.meetjyou.chat
 import com.dogGetDrunk.meetjyou.chat.dto.GetChatMessagesResponse
 import com.dogGetDrunk.meetjyou.chat.dto.GetChatRoomsResponse
 import com.dogGetDrunk.meetjyou.chat.dto.GetUnreadCountResponse
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import com.dogGetDrunk.meetjyou.common.util.SecurityUtil
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
+@RestControllerV1
+@RequestMapping("/chat")
 class ChatReadController(
     private val chatReadService: ChatReadService,
 ) {
 
-    @GetMapping("/api/v1/chat/rooms/{roomUuid}/messages")
+    @GetMapping("/rooms/{roomUuid}/messages")
     fun getMessages(
         @PathVariable roomUuid: UUID,
         @RequestParam(required = false) beforeMessageUuid: UUID?,
@@ -37,7 +39,7 @@ class ChatReadController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/api/v1/chat/rooms/{roomUuid}/unread-count")
+    @GetMapping("/rooms/{roomUuid}/unread-count")
     fun getUnreadCount(
         @PathVariable roomUuid: UUID,
     ): ResponseEntity<GetUnreadCountResponse> {
@@ -51,7 +53,7 @@ class ChatReadController(
         return ResponseEntity.ok(GetUnreadCountResponse(unreadCount = unreadCount))
     }
 
-    @GetMapping("/api/v1/chat/rooms")
+    @GetMapping("/rooms")
     fun getChatRooms(): ResponseEntity<GetChatRoomsResponse> {
         val requesterUuid = SecurityUtil.getCurrentUserUuid()
 
@@ -62,7 +64,7 @@ class ChatReadController(
         return ResponseEntity.ok(response)
     }
 
-    @PostMapping("/api/v1/chat/rooms/{roomUuid}/read")
+    @PostMapping("/rooms/{roomUuid}/read")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun markAsRead(
         @PathVariable roomUuid: UUID,

--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatSwaggerDocController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatSwaggerDocController.kt
@@ -7,13 +7,13 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 
-@RestController
-@RequestMapping("/api/v1/docs/chat")
+@RestControllerV1
+@RequestMapping("/docs/chat")
 class ChatSwaggerDocController {
 
     @Operation(

--- a/src/main/java/com/dogGetDrunk/meetjyou/cloud/oracle/OracleObjectStorageController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/cloud/oracle/OracleObjectStorageController.kt
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1")
+@RestControllerV1
+@RequestMapping
 @Tag(name = "이미지 API", description = "프로필, 모집글, 파티 이미지 관련 API를 제공합니다.")
 class OracleObjectStorageController(
     private val userImgService: UserImgService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/ApiVersionConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/ApiVersionConfig.kt
@@ -1,0 +1,17 @@
+package com.dogGetDrunk.meetjyou.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class ApiVersionConfig : WebMvcConfigurer {
+
+    companion object {
+        const val V1 = "/api/v1"
+    }
+
+    override fun configurePathMatch(configurer: PathMatchConfigurer) {
+        configurer.addPathPrefix(V1) { it.isAnnotationPresent(RestControllerV1::class.java) }
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/RestControllerV1.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/RestControllerV1.kt
@@ -1,0 +1,8 @@
+package com.dogGetDrunk.meetjyou.config
+
+import org.springframework.web.bind.annotation.RestController
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@RestController
+annotation class RestControllerV1

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.dogGetDrunk.meetjyou.config
 
 import com.dogGetDrunk.meetjyou.auth.dev.DevBypassAuthFilter
 import com.dogGetDrunk.meetjyou.auth.jwt.JwtAuthFilter
+import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -26,7 +27,7 @@ class SecurityConfig(
             .authorizeHttpRequests { auth ->
                 auth
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").authenticated()
-                    .requestMatchers("/api/v1/push-tokens").authenticated()
+                    .requestMatchers("$V1/push-tokens").authenticated()
                     .requestMatchers("/actuator/health").permitAll()
                     .requestMatchers("/ws-chat", "/ws-chat/**").permitAll()
                     .requestMatchers("/pub/**", "/sub/**").permitAll()

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
@@ -17,12 +17,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/notices")
+@RestControllerV1
+@RequestMapping("/notices")
 @Tag(name = "공지사항 API")
 class NoticeController(
     private val noticeService: NoticeService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenController.kt
@@ -5,12 +5,12 @@ import com.dogGetDrunk.meetjyou.notification.push.dto.RegisterPushTokenRequest
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
 
-@RestController
-@RequestMapping("/api/v1/push-tokens")
+@RestControllerV1
+@RequestMapping("/push-tokens")
 class PushTokenController(
     private val pushTokenService: PushTokenService,
 ) {

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
@@ -21,13 +21,13 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/parties")
+@RestControllerV1
+@RequestMapping("/parties")
 @Tag(name = "파티 API", description = "여행 파티 생성, 조회, 수정, 삭제 기능 제공")
 class PartyController(
     private val partyService: PartyService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerController.kt
@@ -13,12 +13,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/plans/{planUuid}/markers")
+@RestControllerV1
+@RequestMapping("/plans/{planUuid}/markers")
 @Tag(name = "마커 API", description = "여행 계획 내 마커 조회, 일괄 교체 기능을 제공합니다.")
 class MarkerController(
     private val markerService: MarkerService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanController.kt
@@ -23,12 +23,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/plans")
+@RestControllerV1
+@RequestMapping("/plans")
 @Tag(name = "여행 계획 API", description = "여행 계획 생성, 조회, 수정, 삭제 기능을 제공합니다.")
 class PlanController(
     private val planService: PlanService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostController.kt
@@ -24,12 +24,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/posts")
+@RestControllerV1
+@RequestMapping("/posts")
 @Tag(name = "모집글 API", description = "모집글 생성, 조회, 수정, 삭제 등의 기능을 제공합니다.")
 class PostController(
     private val postService: PostService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/terms/TermsController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/terms/TermsController.kt
@@ -6,11 +6,11 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 
-@RestController
-@RequestMapping("/api/v1/terms")
+@RestControllerV1
+@RequestMapping("/terms")
 @Tag(name = "약관 API", description = "약관 조회 및 약관 본문 다운로드 URL 관련 API를 제공합니다.")
 class TermsController(
     private val termsService: TermsService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthController.kt
@@ -7,15 +7,15 @@ import org.springframework.context.annotation.Profile
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 import java.util.UUID
 
-@RestController
+@RestControllerV1
 @Profile("dev")
-@RequestMapping("/api/v1/dev/auth")
+@RequestMapping("/dev/auth")
 class DevUserAuthController(
     private val devUserAuthService: DevUserAuthService,
 ) {

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.kt
@@ -17,13 +17,13 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/auth")
+@RestControllerV1
+@RequestMapping("/auth")
 @Tag(name = "User authentication controller", description = "유저 인증 관련 API")
 class UserAuthController(
     private val userAuthService: UserAuthService

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
@@ -33,14 +33,14 @@ import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
 import com.dogGetDrunk.meetjyou.common.util.SecurityUtil
 import java.util.UUID
 
-@RestController
-@RequestMapping("/api/v1/users")
+@RestControllerV1
+@RequestMapping("/users")
 @Tag(name = "유저 정보 API")
 class UserController(
     private val userService: UserService,

--- a/src/main/java/com/dogGetDrunk/meetjyou/version/AppVersionController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/version/AppVersionController.kt
@@ -18,12 +18,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
+import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
 
-@RestController
-@RequestMapping("/api/v1/{platform}/versions")
+@RestControllerV1
+@RequestMapping("/{platform}/versions")
 @Tag(name = "앱 버전 관리", description = "iOS/Android 앱 버전 관련 API")
 class AppVersionController(
     private val appVersionService: AppVersionService,


### PR DESCRIPTION
ApiVersionConfig에서 /api/v1 prefix를 중앙 관리하고, 각 컨트롤러는 @RestControllerV1 annotation만 붙이면 자동으로 버전 prefix가 적용된다. v2 추가 시 @RestControllerV2 + ApiVersionConfig 한 줄 추가만으로 확장 가능.