### PR TITLE
fix: 채팅방 목록 조회 시 unreadCount 항상 0으로 반환되는 버그 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
@@ -166,7 +166,8 @@ class ChatReadService(
         }
 
         val rooms = chatRoomRepository.findAllWithPartyByPartyUuidIn(partyByUuid.keys)
-        val roomUuids = rooms.map { it.uuid }
+        val roomUuidToPartyUuid = rooms.associate { it.uuid to it.party.uuid }
+        val roomUuids = roomUuidToPartyUuid.keys.toList()
 
         val latestMessageByRoomUuid = if (roomUuids.isEmpty()) {
             emptyMap()
@@ -176,7 +177,7 @@ class ChatReadService(
         }
 
         val unreadCountByRoomUuid = buildUnreadCountMap(
-            roomUuids = roomUuids,
+            roomUuidToPartyUuid = roomUuidToPartyUuid,
             requesterUuid = requesterUuid,
         )
 
@@ -207,21 +208,23 @@ class ChatReadService(
     }
 
     private fun buildUnreadCountMap(
-        roomUuids: List<UUID>,
+        roomUuidToPartyUuid: Map<UUID, UUID>,
         requesterUuid: UUID,
     ): Map<UUID, Long> {
-        if (roomUuids.isEmpty()) {
+        if (roomUuidToPartyUuid.isEmpty()) {
             return emptyMap()
         }
 
-        val memberships = userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(
+        val partyUuids = roomUuidToPartyUuid.values.toSet()
+
+        val membershipByPartyUuid = userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(
             userUuid = requesterUuid,
             memberStatus = MemberStatus.JOINED,
-        ).filter { it.party.uuid in roomUuids }
+        ).filter { it.party.uuid in partyUuids }
             .associateBy { it.party.uuid }
 
-        val roomUuidsWithoutLastReadMessageId = memberships
-            .filterValues { membership -> membership.lastReadMessageId == null }
+        val roomUuidsWithoutLastReadMessageId = roomUuidToPartyUuid
+            .filterValues { partyUuid -> membershipByPartyUuid[partyUuid]?.lastReadMessageId == null }
             .keys
 
         val unreadMap = mutableMapOf<UUID, Long>()
@@ -235,8 +238,9 @@ class ChatReadService(
             }
         }
 
-        memberships.forEach { (roomUuid, membership) ->
-            val lastReadMessageId = membership.lastReadMessageId ?: return@forEach
+        roomUuidToPartyUuid.forEach { (roomUuid, partyUuid) ->
+            val lastReadMessageId = membershipByPartyUuid[partyUuid]?.lastReadMessageId
+                ?: return@forEach
 
             val projection = chatMessageRepository.countUnreadByRoomUuidAfterLastReadMessageId(
                 roomUuid = roomUuid,


### PR DESCRIPTION
buildUnreadCountMap에서 room.uuid와 party.uuid를 혼용하여 멤버십 필터가 항상 빈 결과를 반환하던 문제 수정. roomUuidToPartyUuid 매핑을 통해
올바른 UUID로 멤버십을 조회하고 unreadMap 키를 room.uuid로 저장.