### PR TITLE
feat: 보안 도메인 강화 — 인증 강제, RBAC, JWT role 플로우 완성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,7 @@ jobs:
             APPLE_CLOCK_SKEW_SECONDS=${{ secrets.APPLE_CLOCK_SKEW_SECONDS }}
             APPLE_JWK_CACHE_TTL_MINUTES=${{ secrets.APPLE_JWK_CACHE_TTL_MINUTES }}
             DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
+            ADMIN_CLAIM_PASSPHRASE=${{ secrets.ADMIN_CLAIM_PASSPHRASE }}
             COMPOSE_PROJECT_NAME=meetjyou
             EOF
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/dev/DevBypassAuthFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/dev/DevBypassAuthFilter.kt
@@ -11,7 +11,6 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher
-import org.springframework.security.web.util.matcher.OrRequestMatcher
 import org.springframework.web.filter.OncePerRequestFilter
 import java.util.UUID
 
@@ -21,12 +20,7 @@ class DevBypassAuthFilter(
 
     private val log = LoggerFactory.getLogger(DevBypassAuthFilter::class.java)
 
-    private val matcher = OrRequestMatcher(
-        AntPathRequestMatcher("/api/v1/parties/**"),
-        AntPathRequestMatcher("/api/v1/posts/**"),
-        AntPathRequestMatcher("/api/v1/plans/**"),
-        AntPathRequestMatcher("/api/v1/users/**"),
-    )
+    private val matcher = AntPathRequestMatcher("/api/v1/**")
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
         if (!props.enabled) return true

--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtAuthFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtAuthFilter.kt
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.stereotype.Component
@@ -44,9 +45,13 @@ class JwtAuthFilter(
         if (token != null && jwtProvider.validateToken(token)) {
             val userUuid: UUID = jwtProvider.getUserUuid(token)
             val email: String = jwtProvider.getUsername(token)
+            val role = jwtProvider.getRole(token)
 
-            // CustomUserPrincipal 생성
-            val principal = CustomUserPrincipal(userUuid, email)
+            val principal = CustomUserPrincipal(
+                uuid = userUuid,
+                email = email,
+                authorities = listOf(SimpleGrantedAuthority(role.name))
+            )
 
             // 인증 객체 구성
             val authentication = UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtProvider.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtProvider.kt
@@ -1,6 +1,7 @@
 package com.dogGetDrunk.meetjyou.auth.jwt
 
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.InvalidJwtException
+import com.dogGetDrunk.meetjyou.user.Role
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
@@ -26,8 +27,8 @@ class JwtProvider(
     private val secretKey: SecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret))
     private val algorithm: MacAlgorithm = Jwts.SIG.HS256
 
-    fun generateAccessToken(userUuid: UUID, email: String): String {
-        return generateToken(userUuid, email, accessTokenExpiration)
+    fun generateAccessToken(userUuid: UUID, email: String, role: Role): String {
+        return generateToken(userUuid, email, role, accessTokenExpiration)
     }
 
     fun generateRefreshToken(userUuid: UUID, email: String): GeneratedRefreshToken {
@@ -50,7 +51,7 @@ class JwtProvider(
         )
     }
 
-    private fun generateToken(userUuid: UUID, email: String, expirationMillis: Long): String {
+    private fun generateToken(userUuid: UUID, email: String, role: Role, expirationMillis: Long): String {
         val now = Date()
         val expiry = Date(now.time + expirationMillis)
 
@@ -58,11 +59,15 @@ class JwtProvider(
             .issuer(issuer)
             .subject(email)
             .claim("userUuid", userUuid.toString())
+            .claim("role", role.name)
             .issuedAt(now)
             .expiration(expiry)
             .signWith(secretKey, algorithm)
             .compact()
     }
+
+    fun getRole(token: String): Role =
+        Role.valueOf(getClaims(token)["role"]?.toString() ?: Role.USER.name)
 
     fun extractToken(request: HttpServletRequest): String? {
         val authHeader = request.getHeader("Authorization") ?: return null

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/CorsConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/CorsConfig.kt
@@ -17,7 +17,6 @@ class CorsConfig(
         val config = CorsConfiguration()
 
         config.allowedOriginPatterns = listOf(
-            "*",
             dnsUrl,
             "http://localhost:*",
             "http://127.0.0.1:*"

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -6,17 +6,27 @@ import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
+@EnableMethodSecurity
 class SecurityConfig(
     private val corsConfig: CorsConfig,
     private val jwtAuthFilter: JwtAuthFilter,
     private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>
 ) {
+
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer =
+        WebSecurityCustomizer { web ->
+            web.ignoring().requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api-doc/**")
+        }
 
     @Bean
     fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
@@ -26,12 +36,27 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { auth ->
                 auth
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").authenticated()
-                    .requestMatchers("$V1/push-tokens").authenticated()
+                    // Infrastructure
                     .requestMatchers("/actuator/health").permitAll()
                     .requestMatchers("/ws-chat", "/ws-chat/**").permitAll()
                     .requestMatchers("/pub/**", "/sub/**").permitAll()
-                    .anyRequest().permitAll() // TODO: 이후 protected endpoint 설정
+                    // Swagger — API 스펙만 노출, 데이터 없음
+                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/api-doc/**").permitAll()
+                    // Auth — no token required (promote-admin requires auth, handled by anyRequest)
+                    .requestMatchers("$V1/auth/registration").permitAll()
+                    .requestMatchers("$V1/auth/nonce").permitAll()
+                    .requestMatchers("$V1/auth/login").permitAll()
+                    .requestMatchers("$V1/auth/refresh").permitAll()
+                    .requestMatchers("$V1/auth/logout").permitAll()
+                    .requestMatchers("$V1/dev/auth/**").permitAll()
+                    // Public read-only
+                    .requestMatchers(HttpMethod.GET, "$V1/notices/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "$V1/terms/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "$V1/*/versions/check").permitAll()
+                    .requestMatchers(HttpMethod.GET, "$V1/*/versions/latest").permitAll()
+                    .requestMatchers(HttpMethod.GET, "$V1/users/is-duplicate-nickname").permitAll()
+                    // All remaining endpoints require a valid JWT
+                    .anyRequest().authenticated()
             }
 
         devBypassAuthFilterProvider.ifAvailable?.let { devBypassFilter ->

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/property/AdminProperties.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/property/AdminProperties.kt
@@ -1,0 +1,8 @@
+package com.dogGetDrunk.meetjyou.config.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "admin")
+data class AdminProperties(
+    val claimPassphrase: String,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -95,6 +96,7 @@ class NoticeController(
             )
         ]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
     fun createNotice(@RequestBody @Valid request: NoticeRequest): ResponseEntity<NoticeResponse> {
         val created = noticeService.createNotice(request)
@@ -130,6 +132,7 @@ class NoticeController(
             )
         ]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{uuid}")
     fun updateNotice(
         @PathVariable uuid: UUID,
@@ -153,6 +156,7 @@ class NoticeController(
             )
         ]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{uuid}")
     fun deleteNotice(@PathVariable uuid: UUID) {
         noticeService.deleteNotice(uuid)

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenController.kt
@@ -2,6 +2,7 @@ package com.dogGetDrunk.meetjyou.notification.push
 
 import com.dogGetDrunk.meetjyou.notification.push.dto.PushTokenResponse
 import com.dogGetDrunk.meetjyou.notification.push.dto.RegisterPushTokenRequest
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -16,7 +17,7 @@ class PushTokenController(
 ) {
 
     @PostMapping
-    fun register(@RequestBody request: RegisterPushTokenRequest): PushTokenResponse {
+    fun register(@Valid @RequestBody request: RegisterPushTokenRequest): PushTokenResponse {
         return pushTokenService.register(request)
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/push/dto/RegisterPushTokenRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/push/dto/RegisterPushTokenRequest.kt
@@ -1,11 +1,16 @@
 package com.dogGetDrunk.meetjyou.notification.push.dto
 
 import com.dogGetDrunk.meetjyou.notification.push.PushToken
+import jakarta.validation.constraints.NotBlank
 
 data class RegisterPushTokenRequest(
+    @field:NotBlank
     val token: String,
+    @field:NotBlank
     val platform: String,
+    @field:NotBlank
     val appVersion: String,
+    @field:NotBlank
     val deviceModel: String,
 ) {
     val platformEnum: PushToken.PushPlatform

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
@@ -95,7 +95,7 @@ class PartyController(
     @PutMapping("/{partyUuid}")
     fun updateParty(
         @PathVariable partyUuid: UUID,
-        @RequestBody request: UpdatePartyRequest,
+        @Valid @RequestBody request: UpdatePartyRequest,
     ): UpdatePartyResponse {
         val userUuid = SecurityUtil.getCurrentUserUuid()
         return partyService.updateParty(partyUuid, userUuid, request)

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -59,7 +60,7 @@ class MarkerController(
     @PutMapping
     fun replaceMarkers(
         @PathVariable planUuid: UUID,
-        @RequestBody request: ReplaceMarkersRequest,
+        @Valid @RequestBody request: ReplaceMarkersRequest,
     ): List<MarkerResponse> {
         return markerService.replaceMarkers(planUuid, request.markers)
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanController.kt
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -50,7 +51,7 @@ class PlanController(
         ]
     )
     @PostMapping
-    fun createPlan(@RequestBody request: CreatePlanRequest): CreatePlanResponse {
+    fun createPlan(@Valid @RequestBody request: CreatePlanRequest): CreatePlanResponse {
         return planService.createPlan(request)
     }
 
@@ -73,7 +74,7 @@ class PlanController(
 
     @Operation(summary = "여행 계획 수정", description = "여행 계획을 수정합니다.")
     @PutMapping("/{planUuid}")
-    fun updatePlan(@PathVariable planUuid: UUID, @RequestBody request: UpdatePlanRequest): UpdatePlanResponse {
+    fun updatePlan(@PathVariable planUuid: UUID, @Valid @RequestBody request: UpdatePlanRequest): UpdatePlanResponse {
         return planService.updatePlan(planUuid, request)
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/CreatePlanRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/CreatePlanRequest.kt
@@ -1,13 +1,22 @@
 package com.dogGetDrunk.meetjyou.plan.dto
 
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.time.Instant
 
 data class CreatePlanRequest(
     val itinStart: Instant,
     val itinFinish: Instant,
+    @field:NotBlank
+    @field:Size(max = 100)
     val location: String,
     val centerLat: Double,
     val centerLng: Double,
+    @field:Size(max = 500)
     val memo: String?,
     val markers: List<CreateMarkerRequest> = emptyList(),
-)
+) {
+    @AssertTrue(message = "일정 종료 시각은 일정 시작 시각 이후여야 합니다.")
+    fun isItinFinishAfterItinStart(): Boolean = itinFinish.isAfter(itinStart)
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/dto/UpdatePlanRequest.kt
@@ -1,13 +1,22 @@
 package com.dogGetDrunk.meetjyou.plan.dto
 
+import jakarta.validation.constraints.AssertTrue
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
 import java.time.Instant
 
 data class UpdatePlanRequest(
     val itinStart: Instant,
     val itinFinish: Instant,
+    @field:NotBlank
+    @field:Size(max = 100)
     val location: String,
     val centerLat: Double,
     val centerLng: Double,
+    @field:Size(max = 500)
     val memo: String?,
     val favorite: Boolean,
-)
+) {
+    @AssertTrue(message = "일정 종료 시각은 일정 시작 시각 이후여야 합니다.")
+    fun isItinFinishAfterItinStart(): Boolean = itinFinish.isAfter(itinStart)
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthService.kt
@@ -58,7 +58,7 @@ class DevUserAuthService(
     }
 
     private fun issueTokenPair(user: User): TokenResponse {
-        val accessToken = jwtProvider.generateAccessToken(user.uuid, user.email)
+        val accessToken = jwtProvider.generateAccessToken(user.uuid, user.email, user.role)
         val generated = jwtProvider.generateRefreshToken(user.uuid, user.email)
         refreshTokenRepository.save(
             RefreshToken(

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/User.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/User.kt
@@ -23,7 +23,7 @@ class User(
     var authProvider: AuthProvider,
     var externalId: String,
     @Enumerated(EnumType.STRING)
-    val role: Role = Role.USER,
+    var role: Role = Role.USER,
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthController.kt
@@ -3,6 +3,7 @@ package com.dogGetDrunk.meetjyou.user
 import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
 import com.dogGetDrunk.meetjyou.user.dto.LoginRequest
 import com.dogGetDrunk.meetjyou.user.dto.NonceResponse
+import com.dogGetDrunk.meetjyou.user.dto.PromoteAdminRequest
 import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequest
 import com.dogGetDrunk.meetjyou.user.dto.TokenResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpSession
 import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -169,5 +171,26 @@ class UserAuthController(
         val refreshToken = authorizationHeader.removePrefix("Bearer ")
         userAuthService.logout(refreshToken)
         return ResponseEntity.noContent().build()
+    }
+
+    @Operation(
+        summary = "관리자 권한 획득",
+        description = "올바른 passphrase를 제출하면 현재 계정을 ADMIN으로 승격하고 새 토큰을 발급합니다. " +
+            "발급된 토큰으로 즉시 관리자 기능을 사용할 수 있습니다."
+    )
+    @ApiResponses(
+        value = [ApiResponse(
+            responseCode = "200",
+            description = "승격 성공 — 새 토큰 반환",
+            content = arrayOf(Content(mediaType = "application/json", schema = Schema(implementation = TokenResponse::class)))
+        ), ApiResponse(
+            responseCode = "403",
+            description = "passphrase 불일치",
+            content = arrayOf(Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class)))
+        )]
+    )
+    @PostMapping("/promote-admin")
+    fun promoteAdmin(@Valid @RequestBody request: PromoteAdminRequest): ResponseEntity<TokenResponse> {
+        return ResponseEntity.ok(userAuthService.claimAdmin(request.passphrase))
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthService.kt
@@ -10,13 +10,17 @@ import com.dogGetDrunk.meetjyou.common.exception.business.jwt.IncorrectJwtSubjec
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.InvalidJwtException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
 import com.dogGetDrunk.meetjyou.common.exception.business.user.UserAlreadyExistsException
+import com.dogGetDrunk.meetjyou.common.util.SecurityUtil
+import com.dogGetDrunk.meetjyou.config.property.AdminProperties
 import com.dogGetDrunk.meetjyou.terms.TermsService
 import com.dogGetDrunk.meetjyou.user.dto.LoginRequest
 import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequest
 import com.dogGetDrunk.meetjyou.user.dto.TokenResponse
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
 
 @Service
 class UserAuthService(
@@ -26,6 +30,7 @@ class UserAuthService(
     private val jwtProvider: JwtProvider,
     private val termsService: TermsService,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val adminProperties: AdminProperties,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -130,8 +135,22 @@ class UserAuthService(
         log.info("User logged out, refresh token revoked. jti: {}", jti)
     }
 
+    @Transactional
+    fun claimAdmin(passphrase: String): TokenResponse {
+        if (passphrase != adminProperties.claimPassphrase) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid passphrase")
+        }
+        val uuid = SecurityUtil.getCurrentUserUuid()
+        val user = userRepository.findByUuid(uuid)
+            ?: throw UserNotFoundException(uuid, message = "User not found during admin claim")
+
+        user.role = Role.ADMIN
+        log.info("User promoted to ADMIN. uuid: {}", user.uuid)
+        return issueTokenPair(user)
+    }
+
     private fun issueTokenPair(user: User): TokenResponse {
-        val accessToken = jwtProvider.generateAccessToken(user.uuid, user.email)
+        val accessToken = jwtProvider.generateAccessToken(user.uuid, user.email, user.role)
         val generated = jwtProvider.generateRefreshToken(user.uuid, user.email)
         refreshTokenRepository.save(
             RefreshToken(

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
@@ -38,6 +38,7 @@ import com.dogGetDrunk.meetjyou.config.RestControllerV1
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import com.dogGetDrunk.meetjyou.common.util.SecurityUtil
+import org.springframework.security.access.prepost.PreAuthorize
 import java.util.UUID
 
 @RestControllerV1
@@ -152,6 +153,7 @@ class UserController(
         return ResponseEntity.ok(updatedUser)
     }
 
+    @PreAuthorize("hasAuthority('ADMIN')")
     @GetMapping
     @ApiResponses(
         value = [ApiResponse(
@@ -265,7 +267,7 @@ class UserController(
     @Operation(summary = "마케팅 정보 수신 동의 변경")
     @ApiResponses(value = [ApiResponse(responseCode = "204", description = "변경 성공")])
     @PatchMapping("/me/marketing-consent")
-    fun updateMarketingConsent(@RequestBody request: UpdateMarketingConsentRequest): ResponseEntity<Unit> {
+    fun updateMarketingConsent(@Valid @RequestBody request: UpdateMarketingConsentRequest): ResponseEntity<Unit> {
         userService.updateMarketingConsent(request.consented)
         return ResponseEntity.noContent().build()
     }
@@ -280,7 +282,7 @@ class UserController(
     @Operation(summary = "푸시 알림 설정 변경", description = "전체 알림 토글 및 카테고리별 알림 설정을 변경합니다. 각 필드는 optional — 전달한 항목만 변경됩니다.")
     @ApiResponses(value = [ApiResponse(responseCode = "204", description = "변경 성공")])
     @PutMapping("/me/notification-settings")
-    fun updateNotificationSettings(@RequestBody request: UpdateNotificationSettingsRequest): ResponseEntity<Unit> {
+    fun updateNotificationSettings(@Valid @RequestBody request: UpdateNotificationSettingsRequest): ResponseEntity<Unit> {
         notificationPreferenceService.updateSettings(request)
         return ResponseEntity.noContent().build()
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/PromoteAdminRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/PromoteAdminRequest.kt
@@ -1,0 +1,8 @@
+package com.dogGetDrunk.meetjyou.user.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class PromoteAdminRequest(
+    @field:NotBlank
+    val passphrase: String,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/version/AppVersionController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/version/AppVersionController.kt
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -77,6 +78,7 @@ class AppVersionController(
             content = [Content(mediaType = "application/json", schema = Schema(type = "array", implementation = AppVersionDto::class))],
         )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @GetMapping
     fun getAllVersions(@PathVariable platform: String): ResponseEntity<List<AppVersionDto>> =
         ResponseEntity.ok(appVersionService.getAllVersions(toPlatform(platform)))
@@ -94,6 +96,7 @@ class AppVersionController(
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
             )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PostMapping
     fun addVersion(
         @PathVariable platform: String,
@@ -113,6 +116,7 @@ class AppVersionController(
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
             )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{version}")
     fun updateVersion(
         @PathVariable platform: String,
@@ -139,6 +143,7 @@ class AppVersionController(
             content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
         )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{version}/force-update")
     fun toggleForceUpdate(
         @PathVariable platform: String,
@@ -158,6 +163,7 @@ class AppVersionController(
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
             )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @PutMapping("/{version}/download-url")
     fun updateDownloadUrl(
         @PathVariable platform: String,
@@ -178,6 +184,7 @@ class AppVersionController(
                 content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
             )]
     )
+    @PreAuthorize("hasAuthority('ADMIN')")
     @DeleteMapping("/{version}")
     fun deleteVersion(
         @PathVariable platform: String,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,6 +18,9 @@ dev:
   bypass:
     enabled: true
 
+admin:
+  claim-passphrase: dev-admin-passphrase
+
 app:
   websocket:
     allowed-origin-patterns:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -111,6 +111,9 @@ dev:
   bypass:
     enabled: false
 
+admin:
+  claim-passphrase: ${ADMIN_CLAIM_PASSPHRASE}
+
 app:
   websocket:
     allowed-origin-patterns:

--- a/src/main/resources/db/migration/V13__seed_admin_user.sql
+++ b/src/main/resources/db/migration/V13__seed_admin_user.sql
@@ -1,0 +1,3 @@
+INSERT INTO user (uuid, email, nickname, auth_provider, external_id, role)
+VALUES ('00000000-0000-0000-0000-000000000001', 'admin@meetjyou.local', '관리자', 'KAKAO', 'admin-system', 'ADMIN')
+ON DUPLICATE KEY UPDATE role = 'ADMIN';

--- a/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatIntegrationTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatIntegrationTest.kt
@@ -64,7 +64,7 @@ class ChatIntegrationTest : BehaviorSpec() {
 
             beforeEach {
                 val data = chatTestDataHelper.createTestData()
-                token = jwtProvider.generateAccessToken(data.userUuid, data.userEmail)
+                token = jwtProvider.generateAccessToken(data.userUuid, data.userEmail, com.dogGetDrunk.meetjyou.user.Role.USER)
                 roomUuid = data.roomUuid
             }
 

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/DevUserAuthServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/DevUserAuthServiceTest.kt
@@ -48,7 +48,7 @@ class DevUserAuthServiceTest : BehaviorSpec() {
 
                     every { userRepository.findByEmail(email) } returns null
                     every { userRepository.save(capture(capturedUser)) } returns newUser
-                    every { jwtProvider.generateAccessToken(any(), any()) } returns "access-token"
+                    every { jwtProvider.generateAccessToken(any(), any(), any()) } returns "access-token"
                     every { jwtProvider.generateRefreshToken(any(), any()) } returns GeneratedRefreshToken(
                         token = "refresh-token",
                         jti = UUID.randomUUID(),
@@ -75,7 +75,7 @@ class DevUserAuthServiceTest : BehaviorSpec() {
                     val existingUser = UserFixtures.user(email = email, nickname = "기존유저")
 
                     every { userRepository.findByEmail(email) } returns existingUser
-                    every { jwtProvider.generateAccessToken(existingUser.uuid, existingUser.email) } returns "access-token"
+                    every { jwtProvider.generateAccessToken(existingUser.uuid, existingUser.email, any()) } returns "access-token"
                     every { jwtProvider.generateRefreshToken(existingUser.uuid, existingUser.email) } returns GeneratedRefreshToken(
                         token = "refresh-token",
                         jti = UUID.randomUUID(),
@@ -101,7 +101,7 @@ class DevUserAuthServiceTest : BehaviorSpec() {
                     val user = UserFixtures.user()
 
                     every { userRepository.findByUuid(user.uuid) } returns user
-                    every { jwtProvider.generateAccessToken(user.uuid, user.email) } returns "access-token"
+                    every { jwtProvider.generateAccessToken(user.uuid, user.email, any()) } returns "access-token"
                     every { jwtProvider.generateRefreshToken(user.uuid, user.email) } returns GeneratedRefreshToken(
                         token = "refresh-token",
                         jti = UUID.randomUUID(),

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/UserAuthServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/UserAuthServiceTest.kt
@@ -8,6 +8,7 @@ import com.dogGetDrunk.meetjyou.auth.support.RefreshTokenFixtures
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.IncorrectJwtSubjectException
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.InvalidJwtException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
+import com.dogGetDrunk.meetjyou.config.property.AdminProperties
 import com.dogGetDrunk.meetjyou.terms.TermsService
 import com.dogGetDrunk.meetjyou.user.support.UserFixtures
 import io.kotest.assertions.throwables.shouldThrow
@@ -29,6 +30,7 @@ class UserAuthServiceTest : BehaviorSpec() {
     private val jwtProvider = mockk<JwtProvider>(relaxed = true)
     private val termsService = mockk<TermsService>(relaxed = true)
     private val refreshTokenRepository = mockk<RefreshTokenRepository>(relaxed = true)
+    private val adminProperties = AdminProperties(claimPassphrase = "test-passphrase")
 
     private val sut = UserAuthService(
         socialVerifierRegistry,
@@ -37,6 +39,7 @@ class UserAuthServiceTest : BehaviorSpec() {
         jwtProvider,
         termsService,
         refreshTokenRepository,
+        adminProperties,
     )
 
     override fun isolationMode() = IsolationMode.InstancePerLeaf
@@ -70,7 +73,7 @@ class UserAuthServiceTest : BehaviorSpec() {
                     every { jwtProvider.getUserUuid(rawToken) } returns user.uuid
                     every { jwtProvider.getUsername(rawToken) } returns user.email
                     every { userRepository.findByUuid(user.uuid) } returns user
-                    every { jwtProvider.generateAccessToken(any(), any()) } returns "new.access.token"
+                    every { jwtProvider.generateAccessToken(any(), any(), any()) } returns "new.access.token"
                     every { jwtProvider.generateRefreshToken(any(), any()) } returns generatedRefreshToken
 
                     val result = sut.refreshToken(rawToken)


### PR DESCRIPTION
- SecurityConfig: anyRequest().permitAll() → authenticated()로 변경, 공개 경로 명시적 허용
- @EnableMethodSecurity 활성화 후 관리자 엔드포인트에 @PreAuthorize("hasAuthority('ADMIN')") 적용 (Notice CUD, AppVersion 관리, 전체 유저 조회)
- JwtProvider: role 클레임 추가 / JwtAuthFilter: role → SimpleGrantedAuthority 주입
- UserAuthService/DevUserAuthService: 토큰 발급 시 user.role 전달
- POST /api/v1/auth/promote-admin: passphrase 검증 후 ADMIN 승격 + 새 토큰 발급
- V13 migration: admin 시드 유저 (UUID 00000000-0000-0000-0000-000000000001)
- CorsConfig: allowCredentials + wildcard 동시 사용 제거
- 컨트롤러 @Valid 누락 6곳 보완, DTO 제약 조건 추가
- DevBypassAuthFilter 매처를 /api/v1/** 전체로 확장
- Swagger: WebSecurityCustomizer.ignoring()으로 필터 체인 완전 우회
- deploy.yml: ADMIN_CLAIM_PASSPHRASE 시크릿 주입