### PR TITLE
fix: 알림 outbox SENDING 고착 및 AFTER_COMMIT throw 유실 버그 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcher.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcher.kt
@@ -38,7 +38,20 @@ class NotificationDispatcher(
         outboxRepository.bulkUpdateStatus(items.map { it.id }, DeliveryStatus.SENDING)
 
         for (item in items) {
-            processItem(item)
+            try {
+                processItem(item)
+            } catch (e: Exception) {
+                log.error("Failed to process outbox item id={}, marking PENDING for retry", item.id, e)
+                mark(item, DeliveryStatus.PENDING, item.attempts, item.availableAt)
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 60_000L)
+    fun reportDeadItems() {
+        val count = outboxRepository.countByStatus(DeliveryStatus.DEAD)
+        if (count > 0) {
+            log.warn("Unresolved DEAD notification outbox items: count={}", count)
         }
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/event/NotificationEventHandler.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/event/NotificationEventHandler.kt
@@ -1,6 +1,5 @@
 package com.dogGetDrunk.meetjyou.notification.event
 
-import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
 import com.dogGetDrunk.meetjyou.notification.NotificationType
 import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutbox
 import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutboxRepository
@@ -25,24 +24,20 @@ class NotificationEventHandler(
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     fun on(event: NotificationEvent) {
-        // 1. UUID로 내부 사용자 조회
         val user = userRepository.findByUuid(event.userUuid) ?: run {
-            log.warn("User not found for UUID: ${event.userUuid}, skipping notification.")
-            throw UserNotFoundException(event.userUuid)
+            log.warn("User not found for UUID: {}, skipping notification.", event.userUuid)
+            return
         }
 
-        // 2. 알림 설정 확인 (전역 토글 + 타입별)
         if (!preferenceService.isEnabled(user, event.payload.type)) {
             log.info("Notification suppressed: type={}, userId={}", event.payload.type, user.id)
             return
         }
 
-        // 3. 템플릿으로 title/body 생성
         val template = templateFactory.templateOf(event.payload.type)
         val title = template.makeTitle(event.preferredLocale, event.payload)
         val body = template.makeBody(event.preferredLocale, event.payload)
 
-        // 5. Outbox에 저장
         val outbox = NotificationOutbox(
             user = user,
             type = NotificationType.valueOf(event.payload.type.name),

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/outbox/NotificationOutboxRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/outbox/NotificationOutboxRepository.kt
@@ -37,4 +37,6 @@ interface NotificationOutboxRepository : JpaRepository<NotificationOutbox, Long>
         @Param("attempts") attempts: Int,
         @Param("availableAt") availableAt: java.time.Instant?,
     )
+
+    fun countByStatus(status: DeliveryStatus): Long
 }

--- a/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
@@ -1,0 +1,86 @@
+package com.dogGetDrunk.meetjyou.notification.dispatcher
+
+import com.dogGetDrunk.meetjyou.notification.NotificationType
+import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutbox
+import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutbox.DeliveryStatus
+import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutboxRepository
+import com.dogGetDrunk.meetjyou.notification.sender.PushNotificationSender
+import com.dogGetDrunk.meetjyou.notification.sender.SendResult
+import com.dogGetDrunk.meetjyou.notification.target.NotificationTargetResolver
+import com.dogGetDrunk.meetjyou.user.support.UserFixtures
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class NotificationDispatcherTest : BehaviorSpec() {
+    private val outboxRepository = mockk<NotificationOutboxRepository>(relaxed = true)
+    private val targetResolver = mockk<NotificationTargetResolver>()
+    private val sender = mockk<PushNotificationSender>()
+    private val objectMapper = ObjectMapper()
+    private val sut = NotificationDispatcher(outboxRepository, targetResolver, sender, objectMapper)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private fun outbox() = NotificationOutbox(
+        user = UserFixtures.user(),
+        type = NotificationType.CHAT_MESSAGE,
+        dataJson = "{}",
+    )
+
+    init {
+        beforeEach { clearAllMocks() }
+
+        given("dispatchBatch 호출 시") {
+
+            `when`("processItem이 예외를 던지면") {
+                then("해당 item이 PENDING으로 재전환된다") {
+                    val item = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
+                    every { targetResolver.resolveUserTargets(any()) } throws RuntimeException("FCM error")
+
+                    sut.dispatchBatch(1)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(item.id, DeliveryStatus.PENDING, item.attempts, item.availableAt)
+                    }
+                    verify(exactly = 0) {
+                        outboxRepository.updateResult(any(), DeliveryStatus.SENT, any(), any())
+                    }
+                }
+            }
+
+            `when`("첫 번째 item이 예외를 던지고 두 번째 item은 정상이면") {
+                then("첫 번째는 PENDING, 두 번째는 SENT로 처리된다") {
+                    val failItem = outbox()
+                    val okItem = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(failItem, okItem)
+                    every { targetResolver.resolveUserTargets(any()) } throws RuntimeException("FCM error") andThen listOf("token-abc")
+                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = true)
+
+                    sut.dispatchBatch(2)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(any(), DeliveryStatus.PENDING, any(), any())
+                    }
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(any(), DeliveryStatus.SENT, any(), any())
+                    }
+                }
+            }
+
+            `when`("item이 없으면") {
+                then("아무 처리도 하지 않는다") {
+                    every { outboxRepository.lockNextPendings(any()) } returns emptyList()
+
+                    sut.dispatchBatch(10)
+
+                    verify(exactly = 0) { outboxRepository.updateResult(any(), any(), any(), any()) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/notification/event/NotificationEventHandlerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notification/event/NotificationEventHandlerTest.kt
@@ -1,0 +1,84 @@
+package com.dogGetDrunk.meetjyou.notification.event
+
+import com.dogGetDrunk.meetjyou.notification.NotificationPayload
+import com.dogGetDrunk.meetjyou.notification.NotificationType
+import com.dogGetDrunk.meetjyou.notification.outbox.NotificationOutboxRepository
+import com.dogGetDrunk.meetjyou.notification.preference.NotificationPreferenceService
+import com.dogGetDrunk.meetjyou.notification.template.NotificationTemplate
+import com.dogGetDrunk.meetjyou.notification.template.NotificationTemplateFactory
+import com.dogGetDrunk.meetjyou.user.UserRepository
+import com.dogGetDrunk.meetjyou.user.support.UserFixtures
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+
+class NotificationEventHandlerTest : BehaviorSpec() {
+    private val templateFactory = mockk<NotificationTemplateFactory>()
+    private val outboxRepository = mockk<NotificationOutboxRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>()
+    private val preferenceService = mockk<NotificationPreferenceService>()
+    private val objectMapper = ObjectMapper()
+    private val sut = NotificationEventHandler(templateFactory, outboxRepository, userRepository, preferenceService, objectMapper)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private fun event(userUuid: UUID = UUID.randomUUID()) = NotificationEvent(
+        userUuid = userUuid,
+        payload = NotificationPayload(type = NotificationType.CHAT_MESSAGE),
+    )
+
+    init {
+        beforeEach { clearAllMocks() }
+
+        given("on(NotificationEvent) 호출 시") {
+
+            `when`("UUID에 해당하는 유저가 없으면") {
+                then("예외 없이 종료되고 outbox가 저장되지 않는다") {
+                    val event = event()
+                    every { userRepository.findByUuid(event.userUuid) } returns null
+
+                    sut.on(event)
+
+                    verify(exactly = 0) { outboxRepository.save(any()) }
+                }
+            }
+
+            `when`("알림 설정이 꺼져 있으면") {
+                then("outbox가 저장되지 않는다") {
+                    val user = UserFixtures.user()
+                    val event = event(user.uuid)
+                    every { userRepository.findByUuid(event.userUuid) } returns user
+                    every { preferenceService.isEnabled(user, NotificationType.CHAT_MESSAGE) } returns false
+
+                    sut.on(event)
+
+                    verify(exactly = 0) { outboxRepository.save(any()) }
+                }
+            }
+
+            `when`("유저가 존재하고 알림 설정이 켜져 있으면") {
+                then("outbox가 저장된다") {
+                    val user = UserFixtures.user()
+                    val event = event(user.uuid)
+                    val template = mockk<NotificationTemplate> {
+                        every { makeTitle(any(), any()) } returns "title"
+                        every { makeBody(any(), any()) } returns "body"
+                    }
+                    every { userRepository.findByUuid(event.userUuid) } returns user
+                    every { preferenceService.isEnabled(user, NotificationType.CHAT_MESSAGE) } returns true
+                    every { templateFactory.templateOf(NotificationType.CHAT_MESSAGE) } returns template
+                    every { outboxRepository.save(any()) } answers { firstArg() }
+
+                    sut.on(event)
+
+                    verify(exactly = 1) { outboxRepository.save(any()) }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- NotificationDispatcher: processItem 예외 시 해당 item을 PENDING으로 재전환해 SENDING 고착 방지
- NotificationDispatcher: DEAD 상태 outbox 건수를 60초마다 WARN 로그로 모니터링
- NotificationEventHandler: AFTER_COMMIT 단계에서 throw 대신 return으로 변경해 알림 유실 방지
- NotificationOutboxRepository: countByStatus 파생 쿼리 추가