### PR TITLE
feat: JWT 인증 오류 예외 구체화

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtAuthFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtAuthFilter.kt
@@ -1,10 +1,14 @@
 package com.dogGetDrunk.meetjyou.auth.jwt
 
 import com.dogGetDrunk.meetjyou.auth.CustomUserPrincipal
+import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
+import com.dogGetDrunk.meetjyou.common.exception.business.jwt.CustomJwtException
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
@@ -16,6 +20,7 @@ import java.util.UUID
 @Component
 class JwtAuthFilter(
     private val jwtProvider: JwtProvider,
+    private val objectMapper: ObjectMapper,
 ) : OncePerRequestFilter() {
 
     val log = LoggerFactory.getLogger(JwtAuthFilter::class.java)
@@ -42,7 +47,16 @@ class JwtAuthFilter(
 
         val token = jwtProvider.extractToken(request)
 
-        if (token != null && jwtProvider.validateToken(token)) {
+        if (token != null) {
+            try {
+                jwtProvider.validateTokenOrThrow(token)
+            } catch (e: CustomJwtException) {
+                response.status = HttpServletResponse.SC_UNAUTHORIZED
+                response.contentType = MediaType.APPLICATION_JSON_VALUE
+                objectMapper.writeValue(response.writer, ErrorResponse(401, e.errorCode, e.value))
+                return
+            }
+
             val userUuid: UUID = jwtProvider.getUserUuid(token)
             val email: String = jwtProvider.getUsername(token)
             val role = jwtProvider.getRole(token)
@@ -53,7 +67,6 @@ class JwtAuthFilter(
                 authorities = listOf(SimpleGrantedAuthority(role.name))
             )
 
-            // 인증 객체 구성
             val authentication = UsernamePasswordAuthenticationToken(
                 principal,
                 null,
@@ -62,7 +75,6 @@ class JwtAuthFilter(
                 details = WebAuthenticationDetailsSource().buildDetails(request)
             }
 
-            // SecurityContextHolder에 주입
             SecurityContextHolder.getContext().authentication = authentication
         }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtProvider.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/jwt/JwtProvider.kt
@@ -1,8 +1,10 @@
 package com.dogGetDrunk.meetjyou.auth.jwt
 
+import com.dogGetDrunk.meetjyou.common.exception.business.jwt.CustomExpiredJwtException
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.InvalidJwtException
 import com.dogGetDrunk.meetjyou.user.Role
 import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.io.Decoders
 import io.jsonwebtoken.security.Keys
@@ -79,6 +81,16 @@ class JwtProvider(
         true
     } catch (e: Exception) {
         false
+    }
+
+    fun validateTokenOrThrow(token: String) {
+        try {
+            getClaims(token)
+        } catch (e: ExpiredJwtException) {
+            throw CustomExpiredJwtException(value = null, message = "Access token expired")
+        } catch (e: Exception) {
+            throw InvalidJwtException(message = "JWT validation failed")
+        }
     }
 
     fun getUsername(token: String): String = getClaims(token).subject

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -2,11 +2,16 @@ package com.dogGetDrunk.meetjyou.config
 
 import com.dogGetDrunk.meetjyou.auth.dev.DevBypassAuthFilter
 import com.dogGetDrunk.meetjyou.auth.jwt.JwtAuthFilter
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode
+import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
 import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
@@ -19,7 +24,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val corsConfig: CorsConfig,
     private val jwtAuthFilter: JwtAuthFilter,
-    private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>
+    private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>,
+    private val objectMapper: ObjectMapper,
 ) {
 
     @Bean
@@ -57,6 +63,16 @@ class SecurityConfig(
                     .requestMatchers(HttpMethod.GET, "$V1/users/is-duplicate-nickname").permitAll()
                     // All remaining endpoints require a valid JWT
                     .anyRequest().authenticated()
+            }
+            .exceptionHandling { exceptions ->
+                exceptions.authenticationEntryPoint { _, response, _ ->
+                    response.status = HttpServletResponse.SC_UNAUTHORIZED
+                    response.contentType = MediaType.APPLICATION_JSON_VALUE
+                    objectMapper.writeValue(
+                        response.writer,
+                        ErrorResponse(401, ErrorCode.MISSING_AUTHORIZATION_HEADER)
+                    )
+                }
             }
 
         devBypassAuthFilterProvider.ifAvailable?.let { devBypassFilter ->


### PR DESCRIPTION
토큰 만료/위변조/누락 각각의 케이스를 UNAUTHENTICATED 대신 구체적인 에러코드로 응답한다.
- JwtProvider: validateTokenOrThrow() 추가 — ExpiredJwtException → CustomExpiredJwtException, 그 외 → InvalidJwtException
- JwtAuthFilter: ObjectMapper로 CustomJwtException 발생 시 즉시 401 JSON 반환
- SecurityConfig: AuthenticationEntryPoint 추가 — 토큰 없이 보호 엔드포인트 접근 시 MISSING_AUTHORIZATION_HEADER 401 반환 (기존 403)