### PR TITLE
feat: ErrorResponse에 errorCode 필드 추가

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorResponse.kt
@@ -2,22 +2,26 @@ package com.dogGetDrunk.meetjyou.common.exception
 
 data class ErrorResponse(
     val status: Int,
+    val errorCode: String,
     val message: String,
     val values: List<String?> = emptyList()
 ) {
     constructor(status: Int, errorCode: ErrorCode) : this(
         status,
+        errorCode.name,
         errorCode.message
     )
 
     constructor(status: Int, errorCode: ErrorCode, value: String?) : this(
         status,
+        errorCode.name,
         errorCode.message,
         listOf(value)
     )
 
     constructor(status: Int, errorCode: ErrorCode, values: List<String?>) : this(
         status,
+        errorCode.name,
         errorCode.message,
         values
     )


### PR DESCRIPTION
프론트엔드에서 에러 분기 시 message 문자열 대신 errorCode enum 이름으로 처리할 수 있도록 응답에 포함한다.