### PR TITLE
fix: FCM 디바이스 토큰 로그 마스킹 처리

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/sender/FcmNotificationSender.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/sender/FcmNotificationSender.kt
@@ -26,11 +26,11 @@ class FcmNotificationSender : PushNotificationSender {
         return try {
             val messageId = FirebaseMessaging.getInstance()
                 .send(message)
-            log.debug("FCM sent ok: token={}, messageId={}", token, messageId)
+            log.debug("FCM sent ok: token={}, messageId={}", "${token.take(10)}...", messageId)
             SendResult(ok = true, messageId = messageId)
         } catch (e: FirebaseMessagingException) {
             val permanent = (e.errorCode.name == "UNREGISTERED" || e.errorCode.name == "INVALID_ARGUMENT")
-            log.warn("FCM send failed: token={}, code={}, permanent={}", token, e.errorCode, permanent, e)
+            log.warn("FCM send failed: token={}, code={}, permanent={}", "${token.take(10)}...", e.errorCode, permanent, e)
             SendResult(ok = false, permanent = permanent, error = e.errorCode.name)
         } catch (e: Exception) {
             log.error("FCM unexpected error", e)


### PR DESCRIPTION
## Summary
- DEBUG/WARN 로그에 FCM 디바이스 토큰 전체가 노출되는 보안 문제 수정
- `token` → `"${token.take(10)}..."` 로 앞 10자리만 출력하도록 마스킹

## Test plan
- [x] `./gradlew test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)