### PR TITLE
perf: 인덱스 추가 및 목록 조회 N+1 쿼리 해소

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerRepository.kt
@@ -6,5 +6,6 @@ import java.util.UUID
 interface MarkerRepository : JpaRepository<Marker, Long> {
     fun findByUuid(uuid: UUID): Marker?
     fun findAllByPlan_UuidOrderByDayNumAscIdxAsc(planUuid: UUID): List<Marker>
+    fun findAllByPlan_UuidIn(planUuids: List<UUID>): List<Marker>
     fun deleteAllByPlan(plan: Plan)
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
@@ -10,6 +10,7 @@ import com.dogGetDrunk.meetjyou.common.util.SecurityUtil
 import com.dogGetDrunk.meetjyou.chat.room.dto.ChatRoomResponse
 import com.dogGetDrunk.meetjyou.party.PartyService
 import com.dogGetDrunk.meetjyou.party.dto.CreatePartyRequest
+import com.dogGetDrunk.meetjyou.plan.Marker
 import com.dogGetDrunk.meetjyou.plan.MarkerRepository
 import com.dogGetDrunk.meetjyou.plan.PlanRepository
 import com.dogGetDrunk.meetjyou.plan.dto.GetPlanResponse
@@ -26,6 +27,7 @@ import com.dogGetDrunk.meetjyou.preference.PreferenceType
 import com.dogGetDrunk.meetjyou.preference.toCompanionSpec
 import com.dogGetDrunk.meetjyou.user.UserRepository
 import com.dogGetDrunk.meetjyou.party.PartyProgressStatus
+import com.dogGetDrunk.meetjyou.userparty.UserParty
 import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
@@ -113,8 +115,23 @@ class PostService(
             throw UserNotFoundException(authorUuid)
         }
 
-        return postRepository.findAllByAuthor_Uuid(authorUuid, pageable)
-            .map { buildGetPostResponse(it) }
+        val posts = postRepository.findAllByAuthor_Uuid(authorUuid, pageable)
+        if (posts.content.isEmpty()) return posts.map { buildGetPostResponse(it) }
+
+        val currentUserUuid = SecurityUtil.getCurrentUserUuid()
+        val planUuids = posts.content.mapNotNull { if (it.isPlanPublic == true) it.plan?.uuid else null }
+        val partyUuids = posts.content.map { it.party.uuid }
+
+        val compPrefsMap = compPreferenceRepository.findAllByPostIn(posts.content).groupBy { it.post.id }
+        val markersMap = if (planUuids.isEmpty()) {
+            emptyMap()
+        } else {
+            markerRepository.findAllByPlan_UuidIn(planUuids).groupBy { it.plan.uuid }
+        }
+        val myStatusMap = userPartyRepository.findAllByParty_UuidInAndUser_Uuid(partyUuids, currentUserUuid)
+            .associateBy { it.party.uuid }
+
+        return posts.map { buildGetPostResponse(it, compPrefsMap, markersMap, myStatusMap) }
     }
 
     @Transactional(readOnly = true)
@@ -124,8 +141,25 @@ class PostService(
 
     @Transactional(readOnly = true)
     fun getAllPosts(pageable: Pageable): Page<GetPostResponse> {
-        return postRepository.findAll(pageable)
-            .map { buildGetPostResponse(it) }
+        val posts = postRepository.findAll(pageable)
+        if (posts.content.isEmpty()) {
+            return posts.map { buildGetPostResponse(it) }
+        }
+
+        val currentUserUuid = SecurityUtil.getCurrentUserUuid()
+        val planUuids = posts.content.mapNotNull { if (it.isPlanPublic == true) it.plan?.uuid else null }
+        val partyUuids = posts.content.map { it.party.uuid }
+
+        val compPrefsMap = compPreferenceRepository.findAllByPostIn(posts.content).groupBy { it.post.id }
+        val markersMap = if (planUuids.isEmpty()) {
+            emptyMap()
+        }   else {
+            markerRepository.findAllByPlan_UuidIn(planUuids).groupBy { it.plan.uuid }
+        }
+        val myStatusMap = userPartyRepository.findAllByParty_UuidInAndUser_Uuid(partyUuids, currentUserUuid)
+            .associateBy { it.party.uuid }
+
+        return posts.map { buildGetPostResponse(it, compPrefsMap, markersMap, myStatusMap) }
     }
 
     @Transactional
@@ -205,6 +239,21 @@ class PostService(
         val myApplicationStatus = userPartyRepository
             .findByParty_UuidAndUser_Uuid(post.party.uuid, currentUserUuid)
             ?.memberStatus
+        return GetPostResponse.of(post, companionSpec, plan, myApplicationStatus)
+    }
+
+    private fun buildGetPostResponse(
+        post: Post,
+        compPrefsMap: Map<Long, List<CompPreference>>,
+        markersMap: Map<UUID, List<Marker>>,
+        myStatusMap: Map<UUID, UserParty>,
+    ): GetPostResponse {
+        val companionSpec = (compPrefsMap[post.id] ?: emptyList()).toCompanionSpec()
+        val plan = if (post.isPlanPublic == true && post.plan != null) {
+            val markers = markersMap[post.plan!!.uuid] ?: emptyList()
+            GetPlanResponse.of(post.plan!!, markers)
+        } else null
+        val myApplicationStatus = myStatusMap[post.party.uuid]?.memberStatus
         return GetPostResponse.of(post, companionSpec, plan, myApplicationStatus)
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/CompPreferenceRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/CompPreferenceRepository.kt
@@ -5,5 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface CompPreferenceRepository : JpaRepository<CompPreference, Long> {
     fun findAllByPost(post: Post): List<CompPreference>
+    fun findAllByPostIn(posts: List<Post>): List<CompPreference>
     fun deleteAllByPost(post: Post)
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreferenceRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/preference/UserPreferenceRepository.kt
@@ -17,4 +17,6 @@ interface UserPreferenceRepository : JpaRepository<UserPreference, Long> {
 
     @Query("SELECT up.preference FROM UserPreference up WHERE up.user.id = :userId AND up.preference.type = :type")
     fun findPreferencesByUserIdAndType(@Param("userId") userId: Long, @Param("type") type: PreferenceType): List<Preference>
+
+    fun findAllByUser_IdIn(userIds: List<Long>): List<UserPreference>
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -108,7 +108,11 @@ class UserService(
 
     @Transactional(readOnly = true)
     fun getAllUsersProfile(): List<BasicUserResponse> {
-        return userRepository.findAll().map { toBasicUserResponse(it) }
+        val users = userRepository.findAll()
+        if (users.isEmpty()) return emptyList()
+        val prefsMap = userPreferenceRepository.findAllByUser_IdIn(users.map { it.id })
+            .groupBy { it.user.id }
+        return users.map { toBasicUserResponse(it, prefsMap[it.id] ?: emptyList()) }
     }
 
     @Transactional
@@ -147,6 +151,29 @@ class UserService(
             travelStyles = getPreferenceNames(user.id, PreferenceType.TRAVEL_STYLE),
             diet = getPreferenceNames(user.id, PreferenceType.DIET),
             etc = getPreferenceNames(user.id, PreferenceType.ETC),
+            authProvider = user.authProvider,
+            marketingConsented = user.marketingConsented,
+        )
+    }
+
+    private fun toBasicUserResponse(user: User, userPrefs: List<UserPreference>): BasicUserResponse {
+        val thumbImgUrl = user.thumbImgUrl ?: defaultProfileImageProvider.getDefaultThumbnailUrl()
+        fun firstName(type: PreferenceType) = userPrefs
+            .firstOrNull { it.preference.type == type }?.preference?.name
+            ?: throw PreferenceNotFoundException(type.name)
+        fun nameList(type: PreferenceType) = userPrefs
+            .filter { it.preference.type == type }.map { it.preference.name }
+        return BasicUserResponse(
+            uuid = user.uuid,
+            nickname = user.nickname,
+            bio = user.bio,
+            thumbImgUrl = thumbImgUrl,
+            gender = firstName(PreferenceType.GENDER),
+            age = firstName(PreferenceType.AGE),
+            personalities = nameList(PreferenceType.PERSONALITY),
+            travelStyles = nameList(PreferenceType.TRAVEL_STYLE),
+            diet = nameList(PreferenceType.DIET),
+            etc = nameList(PreferenceType.ETC),
             authProvider = user.authProvider,
             marketingConsented = user.marketingConsented,
         )

--- a/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
@@ -25,6 +25,11 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
         userUuid: UUID
     ): UserParty?
 
+    fun findAllByParty_UuidInAndUser_Uuid(
+        partyUuids: List<UUID>,
+        userUuid: UUID,
+    ): List<UserParty>
+
     fun findAllByUser_Uuid(
         userUuid: UUID,
         pageable: Pageable

--- a/src/main/resources/db/migration/V15__add_indexes.sql
+++ b/src/main/resources/db/migration/V15__add_indexes.sql
@@ -1,0 +1,11 @@
+-- notification_outbox: @Scheduled(fixedDelay=2000) 마다 풀스캔
+CREATE INDEX idx_notification_outbox_status_available
+    ON notification_outbox (status, available_at);
+
+-- chat_message: 채팅 페이지네이션 조회마다 풀스캔
+CREATE INDEX idx_chat_message_room_cursor
+    ON chat_message (room_id, created_at DESC, id DESC);
+
+-- user_party: 파티/채팅 조회마다 풀스캔
+CREATE INDEX idx_user_party_party_user
+    ON user_party (party_id, user_id);


### PR DESCRIPTION
## Summary

- **V15 마이그레이션**: `notification_outbox`, `chat_message`, `user_party` 테이블에 인덱스 3개 추가
- **PostService N+1 해소**: `getAllPosts` / `getPostByAuthorUuid`에서 게시글당 3쿼리 발생하던 것을 IN 쿼리로 일괄 조회 (N개 게시글 기준 `1+3N` → `4` 쿼리)
- **UserService N+1 해소**: `getAllUsersProfile`에서 유저당 6쿼리 발생하던 것을 IN 쿼리로 일괄 조회 (M명 기준 `1+6M` → `2` 쿼리)

## Changes

| 파일 | 변경 내용 |
|---|---|
| `V15__add_indexes.sql` | notification_outbox / chat_message / user_party 인덱스 추가 |
| `CompPreferenceRepository` | `findAllByPostIn` 추가 |
| `MarkerRepository` | `findAllByPlan_UuidIn` 추가 |
| `UserPartyRepository` | `findAllByParty_UuidInAndUser_Uuid` 추가 |
| `UserPreferenceRepository` | `findAllByUser_IdIn` 추가 |
| `PostService` | 목록 조회 배치 처리, `buildGetPostResponse` 오버로드 추가 |
| `UserService` | 목록 조회 배치 처리, `toBasicUserResponse` 오버로드 추가 |

## Test plan

- [x] `./gradlew test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)