### PR TITLE
test: 핵심 비즈니스 로직 테스트 커버리지 확대

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Meetjyou (만나쥬)** — 여행 동행 찾기 서비스. Kotlin + Spring Boot + MySQL 기반으로 Oracle OCI에 배포되어 있다.
 
+## Branch Check Protocol
+
+본격적인 작업 시작 전, 반드시 `git branch --show-current`로 현재 브랜치를 확인하고 사용자에게 알릴 것. 예상 브랜치가 아닌 경우 작업을 시작하지 말고 사용자에게 확인을 받을 것.
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-./gradlew bootRun                                        # run (dev profile)
+SPRING_PROFILES_ACTIVE=dev,db,secrets \
+  GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/src/main/resources/firebase/meetjyou-firebase-adminsdk.json" \
+  ./gradlew bootRun                                      # run (dev profile, local)
 ./gradlew test                                           # all tests
 ./gradlew test --tests "FullyQualifiedClass.methodName"  # single test
 ```

--- a/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
@@ -25,10 +25,11 @@ class NotificationDispatcherTest : BehaviorSpec() {
 
     override fun isolationMode() = IsolationMode.InstancePerLeaf
 
-    private fun outbox() = NotificationOutbox(
+    private fun outbox(attempts: Int = 0) = NotificationOutbox(
         user = UserFixtures.user(),
         type = NotificationType.CHAT_MESSAGE,
         dataJson = "{}",
+        attempts = attempts,
     )
 
     init {
@@ -79,6 +80,65 @@ class NotificationDispatcherTest : BehaviorSpec() {
                     sut.dispatchBatch(10)
 
                     verify(exactly = 0) { outboxRepository.updateResult(any(), any(), any(), any()) }
+                }
+            }
+
+            `when`("토큰이 없는 유저의 item이면") {
+                then("SENT로 처리된다") {
+                    val item = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
+                    every { targetResolver.resolveUserTargets(any()) } returns emptyList()
+
+                    sut.dispatchBatch(1)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(item.id, DeliveryStatus.SENT, any(), any())
+                    }
+                }
+            }
+
+            `when`("모든 FCM 토큰 전송이 성공하면") {
+                then("SENT로 처리된다") {
+                    val item = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
+                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = true)
+
+                    sut.dispatchBatch(1)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(item.id, DeliveryStatus.SENT, any(), any())
+                    }
+                }
+            }
+
+            `when`("FCM이 영구 실패(permanent=true)를 반환하면") {
+                then("DEAD로 처리된다") {
+                    val item = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
+                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = false, permanent = true)
+
+                    sut.dispatchBatch(1)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(item.id, DeliveryStatus.DEAD, any(), any())
+                    }
+                }
+            }
+
+            `when`("재시도 횟수가 backoff 한도를 초과하면") {
+                then("DEAD로 처리된다") {
+                    val item = outbox(attempts = 4) // nextAttempts=5 >= backoffSeconds.size=5
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
+                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = false)
+
+                    sut.dispatchBatch(1)
+
+                    verify(exactly = 1) {
+                        outboxRepository.updateResult(item.id, DeliveryStatus.DEAD, any(), any())
+                    }
                 }
             }
         }

--- a/src/test/java/com/dogGetDrunk/meetjyou/party/ApproveJoinRequestTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/party/ApproveJoinRequestTest.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
 
 class ApproveJoinRequestTest : BehaviorSpec() {
@@ -71,6 +72,7 @@ class ApproveJoinRequestTest : BehaviorSpec() {
 
                     party.joined shouldBe joinedBefore + 1
                     pendingMembership.memberStatus shouldBe MemberStatus.JOINED
+                    verify(exactly = 2) { publisher.publishEvent(any<Any>()) } // applicant: JOIN_ACCEPTED, host: MEMBER_JOINED
                 }
             }
 


### PR DESCRIPTION
## Summary

- `NotificationDispatcherTest`: 토큰 없음→SENT, 전송 성공→SENT, 영구 실패→DEAD, 재시도 한도 초과→DEAD 시나리오 추가
- `ApproveJoinRequestTest`: 승인 성공 시 알림 이벤트 2회 발행(`PARTY_JOIN_ACCEPTED` + `PARTY_MEMBER_JOINED`) 검증 추가
- `CLAUDE.md`: 브랜치 체크 프로토콜 및 로컬 실행 커맨드 문서화

## Test plan

- [x] `./gradlew test` 전체 통과 (114 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)