### PR TITLE
perf: API 응답 시간 기록 시스템 구축 및 Grafana 연동 준비

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     implementation("org.springframework.security:spring-security-oauth2-jose")
     implementation("org.hibernate.common:hibernate-commons-annotations:7.0.3.Final")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - SPRING_PROFILES_ACTIVE=db,secrets,release
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-adminsdk.json
       - OCI_CONFIG_FILE_PATH=/run/secrets/oci/config
+    ports:
+      - "127.0.0.1:8081:8081"
     volumes:
       - ./data/spring_boot/firebase-adminsdk.json:/run/secrets/firebase-adminsdk.json:ro
       - ./data/spring_boot/oci:/run/secrets/oci:ro

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/filter/RequestLoggingFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/filter/RequestLoggingFilter.kt
@@ -1,0 +1,47 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class RequestLoggingFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger("ACCESS")
+
+    companion object {
+        private const val SLOW_THRESHOLD_MS = 500L
+    }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean {
+        val uri = request.requestURI
+        return uri.startsWith("/actuator/") ||
+            uri.startsWith("/swagger-ui/") ||
+            uri.startsWith("/v3/api-docs")
+    }
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val start = System.currentTimeMillis()
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val duration = System.currentTimeMillis() - start
+            val msg = "${request.method} ${request.requestURI} -> ${response.status} (${duration}ms)"
+            if (duration >= SLOW_THRESHOLD_MS) {
+                log.warn("[SLOW] $msg")
+            } else {
+                log.info(msg)
+            }
+        }
+    }
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeRepository.kt
@@ -9,4 +9,5 @@ interface NoticeRepository : JpaRepository<Notice, Long> {
     fun findByUuid(uuid: UUID): Notice?
     fun existsByUuid(uuid: UUID): Boolean
     fun deleteByUuid(uuid: UUID): Int
+    fun findAllByOrderByCreatedAtDesc(): List<Notice>
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeService.kt
@@ -18,7 +18,7 @@ class NoticeService(
     private val log = LoggerFactory.getLogger(NoticeService::class.java)
 
     fun getAllNotices(): List<NoticeResponse> {
-        return noticeRepository.findAll().map { NoticeResponse.from(it) }
+        return noticeRepository.findAllByOrderByCreatedAtDesc().map { NoticeResponse.from(it) }
     }
 
     fun getNoticeByUuid(uuid: UUID): NoticeResponse {

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
@@ -31,7 +31,7 @@ class NotificationCenterService(
     @Transactional(readOnly = true)
     fun getNotices(userUuid: UUID): NoticesSectionResponse {
         val user = userRepository.findByUuid(userUuid) ?: throw UserNotFoundException(userUuid)
-        val notices = noticeRepository.findAll()
+        val notices = noticeRepository.findAllByOrderByCreatedAtDesc()
         val lastViewed = user.lastNoticesViewedAt
         val unreadCount = if (lastViewed == null) {
             notices.size
@@ -39,7 +39,6 @@ class NotificationCenterService(
             notices.count { it.createdAt.isAfter(lastViewed) }
         }
         val items = notices
-            .sortedByDescending { it.createdAt }
             .map { NoticeItem(uuid = it.uuid, title = it.title, body = it.body, createdAt = it.createdAt) }
         return NoticesSectionResponse(unreadCount = unreadCount, notices = items)
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ server:
   forward-headers-strategy: native
 
 management:
+  server:
+    port: 8081
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,10 +56,18 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, metrics, prometheus
   endpoint:
     health:
       show-details: never
+    metrics:
+      enabled: true
+  metrics:
+    tags:
+      application: meetjyou
+    distribution:
+      percentiles:
+        http.server.requests: 0.5, 0.95, 0.99
 
 dns:
   url: ${DNS_URL}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -22,6 +22,24 @@
             </encoder>
         </appender>
 
+        <appender name="ACCESS_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>logs/access.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>logs/access-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>20MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>100MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <!-- ACCESS logger: file only, suppressed from root console -->
+        <logger name="ACCESS" level="INFO" additivity="false">
+            <appender-ref ref="ACCESS_FILE"/>
+        </logger>
+
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="ERROR_FILE"/>
@@ -29,6 +47,11 @@
     </springProfile>
 
     <springProfile name="!release">
+        <!-- ACCESS logger: console only in dev -->
+        <logger name="ACCESS" level="INFO" additivity="false">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>

--- a/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
@@ -45,7 +45,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                         NotificationCenterFixtures.notice("N1"),
                         NotificationCenterFixtures.notice("N2"),
                     )
-                    every { noticeRepository.findAll() } returns notices
+                    every { noticeRepository.findAllByOrderByCreatedAtDesc() } returns notices
 
                     val result = sut.getNotices(uuid)
 
@@ -60,7 +60,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                         NotificationCenterFixtures.notice("N1"),
                         NotificationCenterFixtures.notice("N2"),
                     )
-                    every { noticeRepository.findAll() } returns notices
+                    every { noticeRepository.findAllByOrderByCreatedAtDesc() } returns notices
                     user.lastNoticesViewedAt = notices.maxOf { it.createdAt }.plusSeconds(1)
 
                     val result = sut.getNotices(uuid)


### PR DESCRIPTION
## Summary
- `RequestLoggingFilter` 추가 — 모든 HTTP 요청의 응답 시간을 `ACCESS` logger로 기록 (500ms 이상은 `[SLOW]` WARN, release에서는 `logs/access.log` 파일로 분리)
- Micrometer Prometheus 레지스트리 추가 및 `/actuator/metrics`, `/actuator/prometheus` 노출 (p50/p95/p99)
- 관리 포트 8081 분리 — Docker 바인딩은 `127.0.0.1`로 제한, OCI 보안 그룹에서 Prometheus 인스턴스 IP만 허용
- `findAll()` 전체 로드 → `findAllByOrderByCreatedAtDesc()` DB 정렬 쿼리 교체 (NoticeService, NotificationCenterService)

## Test plan
- [ ] 전체 테스트 통과 확인 (`./gradlew test`)
- [ ] 배포 후 `logs/access.log` 생성 및 요청 기록 확인
- [ ] `/actuator/prometheus` 응답 확인 (인스턴스 B 또는 내부에서)
- [ ] OCI 보안 그룹 8081 포트 인스턴스 B 사설 IP만 허용

🤖 Generated with [Claude Code](https://claude.com/claude-code)