### PR TITLE
fix: actuator 엔드포인트 Security 인증 우회

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -8,8 +8,10 @@ import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.annotation.Order
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -27,6 +29,16 @@ class SecurityConfig(
     private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>,
     private val objectMapper: ObjectMapper,
 ) {
+
+    @Bean
+    @Order(1)
+    fun managementSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .securityMatcher(EndpointRequest.toAnyEndpoint())
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .csrf { it.disable() }
+        return http.build()
+    }
 
     @Bean
     fun webSecurityCustomizer(): WebSecurityCustomizer =


### PR DESCRIPTION
## Summary
- `/actuator/prometheus`, `/actuator/metrics` 호출 시 JWT 필터에 막혀 401 반환되는 문제 수정
- `EndpointRequest.toAnyEndpoint()` 매처로 actuator 전용 SecurityFilterChain을 `@Order(1)`로 등록해 인증 없이 통과

## Test plan
- [ ] `curl http://localhost:8081/actuator/prometheus` 200 응답 확인
- [ ] 기존 API 엔드포인트 JWT 인증 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)