### PR TITLE
fix: 8081 포트 바인딩을 모든 인터페이스로 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-adminsdk.json
       - OCI_CONFIG_FILE_PATH=/run/secrets/oci/config
     ports:
-      - "127.0.0.1:8081:8081"
+      - "8081:8081"
     volumes:
       - ./data/spring_boot/firebase-adminsdk.json:/run/secrets/firebase-adminsdk.json:ro
       - ./data/spring_boot/oci:/run/secrets/oci:ro


### PR DESCRIPTION
## Summary
- `127.0.0.1:8081:8081` → `8081:8081` 으로 변경
- 인스턴스 B(Prometheus)가 인스턴스 A의 사설 IP:8081로 스크래핑하려면 루프백 제한 불가
- 외부 인터넷 노출 차단은 OCI 보안 그룹(인스턴스 B 사설 IP만 허용)으로 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)