### PR TITLE
chore: 8081 외부 포트 바인딩 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - SPRING_PROFILES_ACTIVE=db,secrets,release
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-adminsdk.json
       - OCI_CONFIG_FILE_PATH=/run/secrets/oci/config
-    ports:
-      - "8081:8081"
     volumes:
       - ./data/spring_boot/firebase-adminsdk.json:/run/secrets/firebase-adminsdk.json:ro
       - ./data/spring_boot/oci:/run/secrets/oci:ro


### PR DESCRIPTION
## Summary
- Alloy가 인스턴스 A 내부에서 localhost:8081로 스크래핑하므로 외부 포트 노출 불필요
- docker-compose.yml에서 `8081:8081` 포트 바인딩 제거
- OCI 보안 그룹 8081 인바운드 규칙도 함께 삭제 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)