### PR TITLE
fix: 8081 포트 바인딩 복구

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - SPRING_PROFILES_ACTIVE=db,secrets,release
       - GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/firebase-adminsdk.json
       - OCI_CONFIG_FILE_PATH=/run/secrets/oci/config
+    ports:
+      - "127.0.0.1:8081:8081"
     volumes:
       - ./data/spring_boot/firebase-adminsdk.json:/run/secrets/firebase-adminsdk.json:ro
       - ./data/spring_boot/oci:/run/secrets/oci:ro


### PR DESCRIPTION
## Summary
- Alloy(호스트)가 Spring Boot(컨테이너) localhost:8081로 스크래핑하려면 포트 바인딩 필요
- `127.0.0.1:8081:8081`로 루프백만 허용해 외부 노출 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)