### PR TITLE
feat: 모집글 모집 상태 변경 엔드포인트 추가

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostController.kt
@@ -6,6 +6,8 @@ import com.dogGetDrunk.meetjyou.post.dto.CreatePostResponse
 import com.dogGetDrunk.meetjyou.post.dto.GetPostResponse
 import com.dogGetDrunk.meetjyou.post.dto.UpdatePostRequest
 import com.dogGetDrunk.meetjyou.post.dto.UpdatePostResponse
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostStatusRequest
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostStatusResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -20,6 +22,7 @@ import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -150,6 +153,39 @@ class PostController(
         @Valid @RequestBody updatePostRequest: UpdatePostRequest
     ): UpdatePostResponse {
         return postService.updatePost(postUuid, updatePostRequest)
+    }
+
+    @Operation(summary = "모집글 모집 상태 변경", description = "모집글의 모집 상태(RECRUITING / RECRUITMENT_COMPLETED)를 변경합니다. 작성자만 변경할 수 있습니다.")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "상태 변경 성공",
+                content = [Content(schema = Schema(implementation = UpdatePostStatusResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 형식",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "403",
+                description = "작성자가 아닌 사용자의 요청",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "postUuid에 해당하는 모집글을 찾을 수 없음",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            )
+        ]
+    )
+    @PatchMapping("/{postUuid}/status")
+    fun updatePostStatus(
+        @PathVariable postUuid: UUID,
+        @Valid @RequestBody request: UpdatePostStatusRequest,
+    ): UpdatePostStatusResponse {
+        return postService.updatePostStatus(postUuid, request)
     }
 
     @Operation(summary = "모집글 삭제", description = "uuid를 통해 모집글을 삭제합니다.")

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
@@ -20,6 +20,8 @@ import com.dogGetDrunk.meetjyou.post.dto.CreatePostResponse
 import com.dogGetDrunk.meetjyou.post.dto.GetPostResponse
 import com.dogGetDrunk.meetjyou.post.dto.UpdatePostRequest
 import com.dogGetDrunk.meetjyou.post.dto.UpdatePostResponse
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostStatusRequest
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostStatusResponse
 import com.dogGetDrunk.meetjyou.post.view.PostViewService
 import com.dogGetDrunk.meetjyou.preference.CompPreference
 import com.dogGetDrunk.meetjyou.preference.CompPreferenceRepository
@@ -218,6 +220,21 @@ class PostService(
 
         log.info("Post updated: ${post.uuid}")
         return UpdatePostResponse.of(post, request.companionSpec)
+    }
+
+    @Transactional
+    fun updatePostStatus(postUuid: UUID, request: UpdatePostStatusRequest): UpdatePostStatusResponse {
+        val post = postRepository.findByUuid(postUuid)
+            ?: throw PostNotFoundException(postUuid)
+        val userUuid = SecurityUtil.getCurrentUserUuid()
+
+        if (userUuid != post.author.uuid) {
+            throw PostUpdateAccessDeniedException(postUuid, post.author.uuid, userUuid)
+        }
+
+        post.status = request.status
+        log.info("Post status updated: uuid={} status={}", postUuid, request.status)
+        return UpdatePostStatusResponse.of(post)
     }
 
     @Transactional

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostStatusRequest.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostStatusRequest.kt
@@ -1,0 +1,9 @@
+package com.dogGetDrunk.meetjyou.post.dto
+
+import com.dogGetDrunk.meetjyou.post.PostStatus
+import jakarta.validation.constraints.NotNull
+
+data class UpdatePostStatusRequest(
+    @field:NotNull(message = "status는 null일 수 없습니다.")
+    val status: PostStatus,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostStatusResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/dto/UpdatePostStatusResponse.kt
@@ -1,0 +1,14 @@
+package com.dogGetDrunk.meetjyou.post.dto
+
+import com.dogGetDrunk.meetjyou.post.Post
+import com.dogGetDrunk.meetjyou.post.PostStatus
+import java.util.UUID
+
+data class UpdatePostStatusResponse(
+    val uuid: UUID,
+    val status: PostStatus,
+) {
+    companion object {
+        fun of(post: Post) = UpdatePostStatusResponse(uuid = post.uuid, status = post.status)
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/post/UpdatePostStatusTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/post/UpdatePostStatusTest.kt
@@ -1,0 +1,27 @@
+package com.dogGetDrunk.meetjyou.post
+
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostStatusRequest
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import jakarta.validation.Validation
+import jakarta.validation.Validator
+
+class UpdatePostStatusTest : BehaviorSpec({
+    val validator: Validator = Validation.buildDefaultValidatorFactory().validator
+
+    Given("UpdatePostStatusRequest 유효성 검사") {
+        When("status가 RECRUITING인 경우") {
+            Then("검증 통과") {
+                val violations = validator.validate(UpdatePostStatusRequest(PostStatus.RECRUITING))
+                violations.isEmpty() shouldBe true
+            }
+        }
+
+        When("status가 RECRUITMENT_COMPLETED인 경우") {
+            Then("검증 통과") {
+                val violations = validator.validate(UpdatePostStatusRequest(PostStatus.RECRUITMENT_COMPLETED))
+                violations.isEmpty() shouldBe true
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- `PATCH /api/v1/posts/{postUuid}/status` 엔드포인트 추가
- 작성자만 상태 변경 가능 (비작성자 → 403, 존재하지 않는 post → 404)
- 요청: `{ "status": "RECRUITING" | "RECRUITMENT_COMPLETED" }` / 응답: `{ "uuid", "status" }`

## Test plan
- [ ] `UpdatePostStatusTest` — 요청 유효성 검사 통과 확인
- [ ] 전체 테스트 통과 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)