### PR TITLE
security: API 데이터 과노출 수정 및 리스트 엔드포인트 페이지네이션 추가

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeController.kt
@@ -10,6 +10,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -43,8 +48,11 @@ class NoticeController(
         ]
     )
     @GetMapping
-    fun getAllNotices(): ResponseEntity<List<NoticeResponse>> {
-        val result = noticeService.getAllNotices()
+    fun getAllNotices(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ResponseEntity<Page<NoticeResponse>> {
+        val result = noticeService.getAllNotices(pageable)
         return ResponseEntity.ok(result)
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeRepository.kt
@@ -1,7 +1,10 @@
 package com.dogGetDrunk.meetjyou.notice
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.Instant
 import java.util.UUID
 
 @Repository
@@ -10,4 +13,6 @@ interface NoticeRepository : JpaRepository<Notice, Long> {
     fun existsByUuid(uuid: UUID): Boolean
     fun deleteByUuid(uuid: UUID): Int
     fun findAllByOrderByCreatedAtDesc(): List<Notice>
+    fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<Notice>
+    fun countByCreatedAtAfter(createdAt: Instant): Long
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notice/NoticeService.kt
@@ -6,6 +6,8 @@ import com.dogGetDrunk.meetjyou.notice.dto.NoticeResponse
 import com.dogGetDrunk.meetjyou.notification.event.NoticeBroadcastEvent
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -17,8 +19,8 @@ class NoticeService(
 ) {
     private val log = LoggerFactory.getLogger(NoticeService::class.java)
 
-    fun getAllNotices(): List<NoticeResponse> {
-        return noticeRepository.findAllByOrderByCreatedAtDesc().map { NoticeResponse.from(it) }
+    fun getAllNotices(pageable: Pageable): Page<NoticeResponse> {
+        return noticeRepository.findAllByOrderByCreatedAtDesc(pageable).map { NoticeResponse.from(it) }
     }
 
     fun getNoticeByUuid(uuid: UUID): NoticeResponse {

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterController.kt
@@ -7,6 +7,10 @@ import com.dogGetDrunk.meetjyou.notificationcenter.dto.ReceivedApplicationsSecti
 import com.dogGetDrunk.meetjyou.notificationcenter.dto.SentApplicationsSectionResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -22,9 +26,12 @@ class NotificationCenterController(
 
     @Operation(summary = "공지사항 목록 조회", description = "전체 공지사항 목록과 읽지 않은 공지 수를 반환합니다.")
     @GetMapping("/notices")
-    fun getNotices(): NoticesSectionResponse {
+    fun getNotices(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): NoticesSectionResponse {
         val userUuid = SecurityUtil.getCurrentUserUuid()
-        return notificationCenterService.getNotices(userUuid)
+        return notificationCenterService.getNotices(userUuid, pageable)
     }
 
     @Operation(summary = "공지사항 읽음 처리", description = "현재 시각을 기준으로 공지사항 읽음 시각을 갱신합니다.")
@@ -37,9 +44,12 @@ class NotificationCenterController(
 
     @Operation(summary = "받은 신청 목록 조회", description = "내가 파티장인 파티에 들어온 PENDING 신청 목록과 읽지 않은 수를 반환합니다.")
     @GetMapping("/received-applications")
-    fun getReceivedApplications(): ReceivedApplicationsSectionResponse {
+    fun getReceivedApplications(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["joinedAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): ReceivedApplicationsSectionResponse {
         val userUuid = SecurityUtil.getCurrentUserUuid()
-        return notificationCenterService.getReceivedApplications(userUuid)
+        return notificationCenterService.getReceivedApplications(userUuid, pageable)
     }
 
     @Operation(summary = "받은 신청 읽음 처리", description = "받은 신청 목록을 전체 읽음 처리합니다.")
@@ -52,9 +62,12 @@ class NotificationCenterController(
 
     @Operation(summary = "보낸 신청 목록 조회", description = "내가 한 파티 신청 목록과 상태 변경 미확인 수를 반환합니다.")
     @GetMapping("/sent-applications")
-    fun getSentApplications(): SentApplicationsSectionResponse {
+    fun getSentApplications(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["statusChangedAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): SentApplicationsSectionResponse {
         val userUuid = SecurityUtil.getCurrentUserUuid()
-        return notificationCenterService.getSentApplications(userUuid)
+        return notificationCenterService.getSentApplications(userUuid, pageable)
     }
 
     @Operation(summary = "보낸 신청 읽음 처리", description = "수락/거절 결과를 전체 읽음 처리합니다.")

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
@@ -14,6 +14,7 @@ import com.dogGetDrunk.meetjyou.user.UserRepository
 import com.dogGetDrunk.meetjyou.userparty.MemberStatus
 import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -29,18 +30,18 @@ class NotificationCenterService(
     private val log = LoggerFactory.getLogger(NotificationCenterService::class.java)
 
     @Transactional(readOnly = true)
-    fun getNotices(userUuid: UUID): NoticesSectionResponse {
+    fun getNotices(userUuid: UUID, pageable: Pageable): NoticesSectionResponse {
         val user = userRepository.findByUuid(userUuid) ?: throw UserNotFoundException(userUuid)
-        val notices = noticeRepository.findAllByOrderByCreatedAtDesc()
         val lastViewed = user.lastNoticesViewedAt
         val unreadCount = if (lastViewed == null) {
-            notices.size
+            noticeRepository.count().toInt()
         } else {
-            notices.count { it.createdAt.isAfter(lastViewed) }
+            noticeRepository.countByCreatedAtAfter(lastViewed).toInt()
         }
-        val items = notices
+        val page = noticeRepository.findAllByOrderByCreatedAtDesc(pageable)
+        val items = page.content
             .map { NoticeItem(uuid = it.uuid, title = it.title, body = it.body, createdAt = it.createdAt) }
-        return NoticesSectionResponse(unreadCount = unreadCount, notices = items)
+        return NoticesSectionResponse(unreadCount = unreadCount, totalCount = page.totalElements, notices = items)
     }
 
     @Transactional
@@ -51,11 +52,16 @@ class NotificationCenterService(
     }
 
     @Transactional(readOnly = true)
-    fun getReceivedApplications(userUuid: UUID): ReceivedApplicationsSectionResponse {
-        val pending = userPartyRepository.findAllPendingRequestsForHost(userUuid)
-        val partyUuids = pending.map { it.party.uuid }
+    fun getReceivedApplications(userUuid: UUID, pageable: Pageable): ReceivedApplicationsSectionResponse {
+        val allPending = userPartyRepository.findAllPendingRequestsForHost(userUuid)
+        val unreadCount = allPending.count { !it.hostRead }
+        val totalCount = allPending.size.toLong()
+        val paged = allPending
+            .drop(pageable.pageNumber * pageable.pageSize)
+            .take(pageable.pageSize)
+        val partyUuids = paged.map { it.party.uuid }
         val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
-        val items = pending.map { up ->
+        val items = paged.map { up ->
             ReceivedApplicationItem(
                 userUuid = up.user.uuid,
                 nickname = up.user.nickname,
@@ -68,8 +74,7 @@ class NotificationCenterService(
                 read = up.hostRead,
             )
         }
-        val unreadCount = items.count { !it.read }
-        return ReceivedApplicationsSectionResponse(unreadCount = unreadCount, applications = items)
+        return ReceivedApplicationsSectionResponse(unreadCount = unreadCount, totalCount = totalCount, applications = items)
     }
 
     @Transactional
@@ -80,11 +85,9 @@ class NotificationCenterService(
     }
 
     @Transactional(readOnly = true)
-    fun getSentApplications(userUuid: UUID): SentApplicationsSectionResponse {
-        val applications = userPartyRepository.findAllSentApplicationsByUserUuid(userUuid)
-        val partyUuids = applications.map { it.party.uuid }
-        val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
-        val items = applications.map { up ->
+    fun getSentApplications(userUuid: UUID, pageable: Pageable): SentApplicationsSectionResponse {
+        val allApplications = userPartyRepository.findAllSentApplicationsByUserUuid(userUuid)
+        val allItems = allApplications.map { up ->
             val status = when (up.memberStatus) {
                 MemberStatus.JOINED    -> ApplicationStatus.ACCEPTED
                 MemberStatus.REJECTED  -> ApplicationStatus.REJECTED
@@ -97,7 +100,7 @@ class NotificationCenterService(
             SentApplicationItem(
                 partyUuid = up.party.uuid,
                 partyName = up.party.name,
-                postUuid = postByPartyUuid[up.party.uuid]?.uuid,
+                postUuid = null,
                 status = status,
                 applicationNote = up.applicationNote,
                 appliedAt = up.joinedAt,
@@ -105,9 +108,16 @@ class NotificationCenterService(
                 read = read,
             )
         }
-        val pendingCount = items.count { it.status == ApplicationStatus.PENDING }
-        val changedCount = items.count { it.status != ApplicationStatus.PENDING && !it.read }
-        return SentApplicationsSectionResponse(pendingCount = pendingCount, changedCount = changedCount, applications = items)
+        val pendingCount = allItems.count { it.status == ApplicationStatus.PENDING }
+        val changedCount = allItems.count { it.status != ApplicationStatus.PENDING && !it.read }
+        val totalCount = allItems.size.toLong()
+        val paged = allItems
+            .drop(pageable.pageNumber * pageable.pageSize)
+            .take(pageable.pageSize)
+        val partyUuids = paged.map { it.partyUuid }
+        val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
+        val pagedWithPost = paged.map { it.copy(postUuid = postByPartyUuid[it.partyUuid]?.uuid) }
+        return SentApplicationsSectionResponse(pendingCount = pendingCount, changedCount = changedCount, totalCount = totalCount, applications = pagedWithPost)
     }
 
     @Transactional

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/NoticesSectionResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/NoticesSectionResponse.kt
@@ -12,5 +12,6 @@ data class NoticeItem(
 
 data class NoticesSectionResponse(
     val unreadCount: Int,
+    val totalCount: Long,
     val notices: List<NoticeItem>,
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/ReceivedApplicationsSectionResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/ReceivedApplicationsSectionResponse.kt
@@ -17,5 +17,6 @@ data class ReceivedApplicationItem(
 
 data class ReceivedApplicationsSectionResponse(
     val unreadCount: Int,
+    val totalCount: Long,
     val applications: List<ReceivedApplicationItem>,
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/SentApplicationsSectionResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/dto/SentApplicationsSectionResponse.kt
@@ -19,5 +19,6 @@ data class SentApplicationItem(
 data class SentApplicationsSectionResponse(
     val pendingCount: Int,
     val changedCount: Int,
+    val totalCount: Long,
     val applications: List<SentApplicationItem>,
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyService.kt
@@ -124,13 +124,14 @@ class PartyService(
     }
 
     @Transactional(readOnly = true)
-    fun getMyParties(userUuid: UUID): List<GetMyPartyResponse> {
-        val memberships = userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(userUuid, MemberStatus.JOINED)
-        val partyUuids = memberships.map { it.party.uuid }
+    fun getMyParties(userUuid: UUID, pageable: Pageable): Page<GetMyPartyResponse> {
+        val membershipPage = userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(userUuid, MemberStatus.JOINED, pageable)
+        val partyUuids = membershipPage.content.map { it.party.uuid }
         val roomByPartyUuid = chatRoomRepository.findAllWithPartyByPartyUuidIn(partyUuids)
             .associateBy { it.party.uuid }
-        return memberships.mapNotNull { userParty ->
-            val chatRoom = roomByPartyUuid[userParty.party.uuid] ?: return@mapNotNull null
+        return membershipPage.map { userParty ->
+            val chatRoom = roomByPartyUuid[userParty.party.uuid]
+                ?: error("ChatRoom not found for party ${userParty.party.uuid}")
             GetMyPartyResponse.of(userParty, chatRoom)
         }
     }
@@ -321,11 +322,11 @@ class PartyService(
     }
 
     @Transactional(readOnly = true)
-    fun getMyApplications(userUuid: UUID): List<MyApplicationResponse> {
-        val applications = userPartyRepository.findAllSentApplicationsByUserUuid(userUuid)
-        val partyUuids = applications.map { it.party.uuid }
+    fun getMyApplications(userUuid: UUID, pageable: Pageable): Page<MyApplicationResponse> {
+        val applicationPage = userPartyRepository.findAllSentApplicationsByUserUuid(userUuid, pageable)
+        val partyUuids = applicationPage.content.map { it.party.uuid }
         val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
-        return applications.map { up ->
+        return applicationPage.map { up ->
             val status = when (up.memberStatus) {
                 MemberStatus.JOINED   -> JoinRequestStatus.ACCEPTED
                 MemberStatus.REJECTED -> JoinRequestStatus.REJECTED

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/DevUserAuthService.kt
@@ -67,6 +67,6 @@ class DevUserAuthService(
                 expiresAt = generated.expiresAt,
             )
         )
-        return TokenResponse(user.uuid, user.email, accessToken, generated.token)
+        return TokenResponse(user.uuid, accessToken, generated.token)
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserAuthService.kt
@@ -159,6 +159,6 @@ class UserAuthService(
                 expiresAt = generated.expiresAt,
             )
         )
-        return TokenResponse(user.uuid, user.email, accessToken, generated.token)
+        return TokenResponse(user.uuid, accessToken, generated.token)
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
@@ -12,6 +12,7 @@ import com.dogGetDrunk.meetjyou.post.PostService
 import com.dogGetDrunk.meetjyou.post.dto.GetPostResponse
 import com.dogGetDrunk.meetjyou.user.dto.AdvancedUserResponse
 import com.dogGetDrunk.meetjyou.user.dto.BasicUserResponse
+import com.dogGetDrunk.meetjyou.user.dto.PublicUserResponse
 import com.dogGetDrunk.meetjyou.user.dto.UpdateMarketingConsentRequest
 import com.dogGetDrunk.meetjyou.user.dto.UserUpdateRequest
 import io.swagger.v3.oas.annotations.Operation
@@ -77,9 +78,8 @@ class UserController(
         )]
     )
     @GetMapping("/{uuid}/basic-info")
-    fun getBasicUserProfile(@PathVariable uuid: UUID): ResponseEntity<BasicUserResponse> {
-        val response = userService.getUserProfile(uuid)
-        return ResponseEntity.ok(response)
+    fun getBasicUserProfile(@PathVariable uuid: UUID): ResponseEntity<PublicUserResponse> {
+        return ResponseEntity.ok(userService.getPublicUserProfile(uuid))
     }
 
     @Operation(summary = "유저의 모든 정보 조회", description = "유저의 기본 정보, 라이프스타일 및 작성한 모집글을 조회합니다.")
@@ -109,9 +109,23 @@ class UserController(
         @PathVariable uuid: UUID,
         @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): ResponseEntity<AdvancedUserResponse> {
-        val basicUserResponseDto: BasicUserResponse = userService.getUserProfile(uuid)
+        val publicUserResponse: PublicUserResponse = userService.getPublicUserProfile(uuid)
         val posts: Page<GetPostResponse> = postService.getPostByAuthorUuid(uuid, pageable)
-        return ResponseEntity.ok(AdvancedUserResponse(basicUserResponseDto, posts))
+        return ResponseEntity.ok(AdvancedUserResponse(publicUserResponse, posts))
+    }
+
+    @Operation(summary = "내 프로필 조회", description = "현재 로그인한 사용자의 전체 프로필(authProvider, 마케팅 동의 여부 포함)을 조회합니다.")
+    @ApiResponses(
+        value = [ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = arrayOf(Content(mediaType = "application/json", schema = Schema(implementation = BasicUserResponse::class)))
+        )]
+    )
+    @GetMapping("/me/profile")
+    fun getMyProfile(): ResponseEntity<BasicUserResponse> {
+        val uuid = SecurityUtil.getCurrentUserUuid()
+        return ResponseEntity.ok(userService.getUserProfile(uuid))
     }
 
     @Operation(summary = "유저 정보 수정", description = "유저의 닉네임, 한 줄 소개, 성별, 나이 및 라이프스타일을 수정합니다.")
@@ -231,17 +245,23 @@ class UserController(
     @Operation(summary = "내 파티 목록 조회", description = "현재 로그인한 사용자가 참여 중인 파티 목록을 채팅방 정보와 함께 조회합니다.")
     @ApiResponses(value = [ApiResponse(responseCode = "200", description = "조회 성공")])
     @GetMapping("/me/parties")
-    fun getMyParties(): ResponseEntity<List<GetMyPartyResponse>> {
+    fun getMyParties(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["joinedAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): Page<GetMyPartyResponse> {
         val userUuid = SecurityUtil.getCurrentUserUuid()
-        return ResponseEntity.ok(partyService.getMyParties(userUuid))
+        return partyService.getMyParties(userUuid, pageable)
     }
 
     @Operation(summary = "내 파티 신청 목록 조회", description = "현재 로그인한 사용자가 신청한 파티 신청 목록을 상태와 함께 조회합니다.")
     @ApiResponses(value = [ApiResponse(responseCode = "200", description = "조회 성공")])
     @GetMapping("/me/applications")
-    fun getMyApplications(): ResponseEntity<List<MyApplicationResponse>> {
+    fun getMyApplications(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["statusChangedAt"], direction = Sort.Direction.DESC) pageable: Pageable,
+    ): Page<MyApplicationResponse> {
         val userUuid = SecurityUtil.getCurrentUserUuid()
-        return ResponseEntity.ok(partyService.getMyApplications(userUuid))
+        return partyService.getMyApplications(userUuid, pageable)
     }
 
     @Operation(summary = "내 모집글 목록 조회", description = "현재 로그인한 사용자가 작성한 모집글 목록을 조회합니다.")

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -12,6 +12,7 @@ import com.dogGetDrunk.meetjyou.preference.PreferenceType
 import com.dogGetDrunk.meetjyou.preference.UserPreference
 import com.dogGetDrunk.meetjyou.preference.UserPreferenceRepository
 import com.dogGetDrunk.meetjyou.user.dto.BasicUserResponse
+import com.dogGetDrunk.meetjyou.user.dto.PublicUserResponse
 import com.dogGetDrunk.meetjyou.user.dto.RegistrationRequest
 import com.dogGetDrunk.meetjyou.user.dto.UserUpdateRequest
 import com.dogGetDrunk.meetjyou.user.dto.normalizeOrNull
@@ -107,6 +108,14 @@ class UserService(
     }
 
     @Transactional(readOnly = true)
+    fun getPublicUserProfile(uuid: UUID): PublicUserResponse {
+        val user = userRepository.findByUuid(uuid)
+            ?: throw UserNotFoundException(uuid)
+
+        return toPublicUserResponse(user)
+    }
+
+    @Transactional(readOnly = true)
     fun getAllUsersProfile(): List<BasicUserResponse> {
         val users = userRepository.findAll()
         if (users.isEmpty()) return emptyList()
@@ -136,6 +145,22 @@ class UserService(
         val uuid = SecurityUtil.getCurrentUserUuid()
         val user = userRepository.findByUuid(uuid) ?: throw UserNotFoundException(uuid)
         user.marketingConsented = consented
+    }
+
+    private fun toPublicUserResponse(user: User): PublicUserResponse {
+        val thumbImgUrl = user.thumbImgUrl ?: defaultProfileImageProvider.getDefaultThumbnailUrl()
+        return PublicUserResponse(
+            uuid = user.uuid,
+            nickname = user.nickname,
+            bio = user.bio,
+            thumbImgUrl = thumbImgUrl,
+            gender = getPreferenceName(user.id, PreferenceType.GENDER),
+            age = getPreferenceName(user.id, PreferenceType.AGE),
+            personalities = getPreferenceNames(user.id, PreferenceType.PERSONALITY),
+            travelStyles = getPreferenceNames(user.id, PreferenceType.TRAVEL_STYLE),
+            diet = getPreferenceNames(user.id, PreferenceType.DIET),
+            etc = getPreferenceNames(user.id, PreferenceType.ETC),
+        )
     }
 
     private fun toBasicUserResponse(user: User): BasicUserResponse {

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/AdvancedUserResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/AdvancedUserResponse.kt
@@ -4,6 +4,6 @@ import com.dogGetDrunk.meetjyou.post.dto.GetPostResponse
 import org.springframework.data.domain.Page
 
 data class AdvancedUserResponse(
-    val basicUserInfo: BasicUserResponse,
+    val basicUserInfo: PublicUserResponse,
     val posts: Page<GetPostResponse>
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/PublicUserResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/PublicUserResponse.kt
@@ -1,0 +1,16 @@
+package com.dogGetDrunk.meetjyou.user.dto
+
+import java.util.UUID
+
+data class PublicUserResponse(
+    val uuid: UUID,
+    val nickname: String,
+    val bio: String?,
+    val thumbImgUrl: String?,
+    val gender: String,
+    val age: String,
+    val personalities: List<String>,
+    val travelStyles: List<String>,
+    val diet: List<String>,
+    val etc: List<String>,
+)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponse.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/dto/TokenResponse.kt
@@ -4,7 +4,6 @@ import java.util.UUID
 
 data class TokenResponse(
     val uuid: UUID,
-    val email: String,
     val accessToken: String,
     val refreshToken: String
 )

--- a/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
@@ -72,6 +72,27 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
         @Param("memberStatus") memberStatus: MemberStatus,
     ): List<UserParty>
 
+    @Query(
+        value = """
+            select up
+            from UserParty up
+            join fetch up.party
+            where up.user.uuid = :userUuid
+              and up.memberStatus = :memberStatus
+        """,
+        countQuery = """
+            select count(up)
+            from UserParty up
+            where up.user.uuid = :userUuid
+              and up.memberStatus = :memberStatus
+        """
+    )
+    fun findAllWithPartyByUserUuidAndMemberStatus(
+        @Param("userUuid") userUuid: UUID,
+        @Param("memberStatus") memberStatus: MemberStatus,
+        pageable: Pageable,
+    ): Page<UserParty>
+
     fun existsByParty_Plan_UuidAndUser_UuidAndMemberStatus(
         planUuid: UUID,
         userUuid: UUID,
@@ -104,5 +125,25 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
         order by up.statusChangedAt desc
     """)
     fun findAllSentApplicationsByUserUuid(@Param("userUuid") userUuid: UUID): List<UserParty>
+
+    @Query(
+        value = """
+            select up from UserParty up
+            join fetch up.party
+            where up.user.uuid = :userUuid
+            and up.role = 'MEMBER'
+            and up.memberStatus in ('PENDING', 'JOINED', 'REJECTED')
+        """,
+        countQuery = """
+            select count(up) from UserParty up
+            where up.user.uuid = :userUuid
+            and up.role = 'MEMBER'
+            and up.memberStatus in ('PENDING', 'JOINED', 'REJECTED')
+        """
+    )
+    fun findAllSentApplicationsByUserUuid(
+        @Param("userUuid") userUuid: UUID,
+        pageable: Pageable,
+    ): Page<UserParty>
 
 }

--- a/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
@@ -17,6 +17,8 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class NotificationCenterServiceTest : BehaviorSpec() {
 
@@ -45,9 +47,11 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                         NotificationCenterFixtures.notice("N1"),
                         NotificationCenterFixtures.notice("N2"),
                     )
-                    every { noticeRepository.findAllByOrderByCreatedAtDesc() } returns notices
+                    val pageable = Pageable.ofSize(20)
+                    every { noticeRepository.count() } returns 2
+                    every { noticeRepository.findAllByOrderByCreatedAtDesc(pageable) } returns PageImpl(notices)
 
-                    val result = sut.getNotices(uuid)
+                    val result = sut.getNotices(uuid, pageable)
 
                     result.unreadCount shouldBe 2
                     result.notices.size shouldBe 2
@@ -60,10 +64,12 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                         NotificationCenterFixtures.notice("N1"),
                         NotificationCenterFixtures.notice("N2"),
                     )
-                    every { noticeRepository.findAllByOrderByCreatedAtDesc() } returns notices
+                    val pageable = Pageable.ofSize(20)
+                    every { noticeRepository.countByCreatedAtAfter(any()) } returns 0
+                    every { noticeRepository.findAllByOrderByCreatedAtDesc(pageable) } returns PageImpl(notices)
                     user.lastNoticesViewedAt = notices.maxOf { it.createdAt }.plusSeconds(1)
 
-                    val result = sut.getNotices(uuid)
+                    val result = sut.getNotices(uuid, pageable)
 
                     result.unreadCount shouldBe 0
                 }
@@ -73,7 +79,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                 then("UserNotFoundException을 던진다") {
                     every { userRepository.findByUuid(uuid) } returns null
 
-                    shouldThrow<UserNotFoundException> { sut.getNotices(uuid) }
+                    shouldThrow<UserNotFoundException> { sut.getNotices(uuid, Pageable.ofSize(20)) }
                 }
             }
         }
@@ -110,7 +116,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                     every { userPartyRepository.findAllPendingRequestsForHost(hostUuid) } returns listOf(pending)
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getReceivedApplications(hostUuid)
+                    val result = sut.getReceivedApplications(hostUuid, Pageable.ofSize(20))
 
                     result.unreadCount shouldBe 1
                     result.applications.size shouldBe 1
@@ -125,7 +131,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                     every { userPartyRepository.findAllPendingRequestsForHost(hostUuid) } returns emptyList()
                     every { postRepository.findAllByParty_UuidIn(emptyList()) } returns emptyList()
 
-                    val result = sut.getReceivedApplications(hostUuid)
+                    val result = sut.getReceivedApplications(hostUuid, Pageable.ofSize(20))
 
                     result.unreadCount shouldBe 0
                     result.applications shouldBe emptyList()
@@ -167,7 +173,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                     every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(pending)
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(userUuid)
+                    val result = sut.getSentApplications(userUuid, Pageable.ofSize(20))
 
                     result.pendingCount shouldBe 1
                     result.changedCount shouldBe 0
@@ -183,7 +189,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                     every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(accepted)
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(userUuid)
+                    val result = sut.getSentApplications(userUuid, Pageable.ofSize(20))
 
                     result.changedCount shouldBe 1
                     result.applications[0].status shouldBe ApplicationStatus.ACCEPTED
@@ -198,7 +204,7 @@ class NotificationCenterServiceTest : BehaviorSpec() {
                     every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(rejected)
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(userUuid)
+                    val result = sut.getSentApplications(userUuid, Pageable.ofSize(20))
 
                     result.changedCount shouldBe 1
                     result.applications[0].status shouldBe ApplicationStatus.REJECTED

--- a/src/test/java/com/dogGetDrunk/meetjyou/party/GetPendingJoinRequestsTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/party/GetPendingJoinRequestsTest.kt
@@ -20,6 +20,8 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 
 class GetPendingJoinRequestsTest : BehaviorSpec() {
 
@@ -80,15 +82,16 @@ class GetPendingJoinRequestsTest : BehaviorSpec() {
                     val accepted = NotificationCenterFixtures.pendingUserParty(party2, user)
                     accepted.approve()
 
-                    every { userPartyRepository.findAllSentApplicationsByUserUuid(user.uuid) } returns listOf(pending, accepted)
+                    val pageable = Pageable.ofSize(20)
+                    every { userPartyRepository.findAllSentApplicationsByUserUuid(user.uuid, pageable) } returns PageImpl(listOf(pending, accepted))
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid, party2.uuid)) } returns listOf(post, post2)
 
-                    val result = sut.getMyApplications(user.uuid)
+                    val result = sut.getMyApplications(user.uuid, pageable)
 
-                    result.size shouldBe 2
-                    result[0].status shouldBe JoinRequestStatus.PENDING
-                    result[0].applicationNote shouldBe "note"
-                    result[1].status shouldBe JoinRequestStatus.ACCEPTED
+                    result.content.size shouldBe 2
+                    result.content[0].status shouldBe JoinRequestStatus.PENDING
+                    result.content[0].applicationNote shouldBe "note"
+                    result.content[1].status shouldBe JoinRequestStatus.ACCEPTED
                 }
             }
         }

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/DevUserAuthServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/DevUserAuthServiceTest.kt
@@ -62,7 +62,6 @@ class DevUserAuthServiceTest : BehaviorSpec() {
                     capturedUser.captured.authProvider shouldBe AuthProvider.KAKAO
                     capturedUser.captured.externalId shouldBe "dev-$email"
                     result.uuid shouldBe newUser.uuid
-                    result.email shouldBe newUser.email
                     result.accessToken shouldBe "access-token"
                     result.refreshToken shouldBe "refresh-token"
                 }
@@ -86,7 +85,6 @@ class DevUserAuthServiceTest : BehaviorSpec() {
 
                     verify(exactly = 0) { userRepository.save(any()) }
                     result.uuid shouldBe existingUser.uuid
-                    result.email shouldBe existingUser.email
                     result.accessToken shouldBe "access-token"
                     result.refreshToken shouldBe "refresh-token"
                 }
@@ -111,7 +109,6 @@ class DevUserAuthServiceTest : BehaviorSpec() {
                     val result = sut.getTokenForUser(user.uuid)
 
                     result.uuid shouldBe user.uuid
-                    result.email shouldBe user.email
                     result.accessToken shouldBe "access-token"
                     result.refreshToken shouldBe "refresh-token"
                 }

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/UserAuthServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/UserAuthServiceTest.kt
@@ -83,7 +83,6 @@ class UserAuthServiceTest : BehaviorSpec() {
                     result.accessToken shouldBe "new.access.token"
                     result.refreshToken shouldBe "new.refresh.token"
                     result.uuid shouldBe user.uuid
-                    result.email shouldBe user.email
                 }
             }
 


### PR DESCRIPTION
## Summary

- **TokenResponse email 제거**: 로그인/회원가입/토큰갱신 응답에서 불필요한 PII(email) 노출 제거
- **유저 프로필 응답 분리**: `PublicUserResponse` 신규 DTO 도입으로 타인 조회 시 민감 필드(`authProvider`, `marketingConsented`) 노출 차단
- **`GET /users/me/profile` 추가**: 본인 전용 전체 프로필 조회 엔드포인트 신설
- **리스트 엔드포인트 페이지네이션**: `GET /notices`, `GET /users/me/parties`, `GET /users/me/applications`, 알림센터 3종에 페이지네이션 적용

## API Changes (프론트 대응 필요)

### 1. 로그인/회원가입 응답 — `email` 필드 제거
- 대상: `POST /v1/auth/login`, `/v1/auth/registration`, `/v1/auth/refresh`

### 2. 유저 프로필 조회 응답 변경
- `GET /v1/users/{uuid}/basic-info` → `authProvider`, `marketingConsented` 필드 제거됨 (`PublicUserResponse`)
- `GET /v1/users/{uuid}/advanced-info` → 동일하게 `basicUserInfo` 필드 구조 변경
- `GET /v1/users/me/profile` (신규) → `authProvider`, `marketingConsented` 포함한 전체 프로필

### 3. 리스트 엔드포인트 → Page 구조로 변경
- `GET /v1/notices` → `Page<NoticeResponse>` (content, totalElements, totalPages 등 포함)
- `GET /v1/users/me/parties` → `Page<GetMyPartyResponse>`
- `GET /v1/users/me/applications` → `Page<MyApplicationResponse>`
- 알림센터 (`/notification-center/notices`, `/received-applications`, `/sent-applications`) → 응답에 `totalCount` 필드 추가, `page`/`size` 쿼리 파라미터 지원

## Test plan
- [x] 전체 테스트 통과 (`./gradlew test`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)