### PR TITLE
ci: PR 시 빌드/테스트 검증하는 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Amazon Corretto JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+
+      - name: Build & Test
+        run: ./gradlew build --no-daemon
+
+      - name: Upload test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test


### PR DESCRIPTION
## Summary
- main에 push할 때만 배포되고 별도 검증 단계가 없던 문제를 보완: PR 생성 시 `./gradlew build`(컴파일+테스트)를 실행하는 CI 워크플로우 추가
- main 브랜치 보호 규칙도 함께 설정: PR 필수, CI(`build-and-test`) 통과 필수, 직접 push/force-push/삭제 금지(관리자 포함)

## Test plan
- [x] 로컬에서 `GOOGLE_APPLICATION_CREDENTIALS` 없이 `./gradlew test` 실행되는 것 확인 (Firebase/OCI 빈은 테스트에서 `@MockBean`으로 대체되므로 CI에서 추가 시크릿 불필요)
- [x] 이 PR이 CI를 통과하는지 확인