### PR TITLE
ci: 배포 이미지에 git SHA 태그 부여 및 헬스체크 기반 자동 롤백 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Docker 이미지 빌드 & 푸시
+      - name: Docker 이미지 빌드 & 푸시 (latest + git SHA 태그)
         run: |
-          docker buildx build --platform linux/amd64 -t ${{ secrets.DOCKER_USERNAME }}/meetjyou:latest .
-          docker push ${{ secrets.DOCKER_USERNAME }}/meetjyou:latest
+          docker buildx build --platform linux/amd64 \
+            -t ${{ secrets.DOCKER_USERNAME }}/meetjyou:latest \
+            -t ${{ secrets.DOCKER_USERNAME }}/meetjyou:${{ github.sha }} \
+            --push .
 
       - name: 서버에 docker-compose.yml 업로드
         uses: appleboy/scp-action@master
@@ -84,9 +86,10 @@ jobs:
             DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
             ADMIN_CLAIM_PASSPHRASE=${{ secrets.ADMIN_CLAIM_PASSPHRASE }}
             COMPOSE_PROJECT_NAME=meetjyou
+            IMAGE_TAG=${{ github.sha }}
             EOF
 
-      - name: 기존 컨테이너 정리
+      - name: 배포 + 헬스체크 + 실패 시 자동 롤백
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.ORACLE_CLOUD_HOST }}
@@ -95,14 +98,29 @@ jobs:
           script: |
             cd ~/meetjyou
             docker-compose down || true
-
-      - name: SSH를 통한 오라클 클라우드 인스턴스 배포
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.ORACLE_CLOUD_HOST }}
-          username: ${{ secrets.ORACLE_CLOUD_USER }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            cd ~/meetjyou
             docker-compose pull
             docker-compose up -d
+
+            echo "헬스체크 대기 중..."
+            HEALTHY=false
+            for i in $(seq 1 20); do
+              if curl -sf http://127.0.0.1:8081/actuator/health | grep -q '"status":"UP"'; then
+                HEALTHY=true
+                break
+              fi
+              sleep 5
+            done
+
+            if [ "$HEALTHY" = "true" ]; then
+              echo "${{ github.sha }}" > CURRENT_TAG
+              echo "배포 성공: ${{ github.sha }}"
+            else
+              echo "헬스체크 실패, 이전 버전으로 롤백합니다."
+              PREV_TAG=$(cat CURRENT_TAG 2>/dev/null || echo "latest")
+              sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$PREV_TAG/" .env
+              docker-compose down
+              docker-compose pull
+              docker-compose up -d
+              echo "롤백 완료: $PREV_TAG"
+              exit 1
+            fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,9 +101,9 @@ jobs:
             docker-compose pull
             docker-compose up -d
 
-            echo "헬스체크 대기 중..."
+            echo "헬스체크 대기 중... (OCI 프리티어 기동 시간을 고려해 최대 210초 대기)"
             HEALTHY=false
-            for i in $(seq 1 20); do
+            for i in $(seq 1 42); do
               if curl -sf http://127.0.0.1:8081/actuator/health | grep -q '"status":"UP"'; then
                 HEALTHY=true
                 break

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   spring_boot:
     container_name: spring_boot
     restart: always
-    image: ssove/meetjyou
+    image: ssove/meetjyou:${IMAGE_TAG:-latest}
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Summary
- Docker 이미지를 `latest` 뿐 아니라 `git SHA`로도 태깅하여 push (`docker-compose.yml`은 `IMAGE_TAG` 환경변수로 태그를 주입받도록 변경)
- 배포 후 `http://127.0.0.1:8081/actuator/health`를 최대 100초(5초 x 20회) 폴링해서 `UP` 상태를 확인
- 헬스체크 통과 시 `CURRENT_TAG` 파일에 배포된 SHA를 기록 (다음 배포의 롤백 기준점)
- 헬스체크 실패 시 직전 성공 SHA(`CURRENT_TAG`)로 자동 롤백하고 워크플로우를 실패 처리(Actions에서 바로 확인 가능)

## Why
기존엔 latest 태그 하나만 사용해 배포 실패 시 되돌릴 이미지가 없었고, 컨테이너가 죽어도 워크플로우는 성공으로 표시됐음. 문제가 생기면 "고치는 커밋을 또 push"하는 것 외엔 선택지가 없어 브랜치 히스토리가 지저분해지는 원인이었음.

## Test plan
- [x] `docker-compose.yml` / `deploy.yml` YAML 문법 검증 (`python -c "import yaml; ..."`)
- [ ] 이 PR을 머지한 뒤 실제 배포에서 정상 헬스체크 통과 확인
- [ ] (선택) 의도적으로 헬스체크 실패를 유발해 롤백 동작 확인