### PR TITLE
feat: 인증 엔드포인트에 IP 기반 rate limiting 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     // Cache library - Caffeine
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
 
+    // Rate limiting
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
+
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.kt
@@ -89,4 +89,7 @@ enum class ErrorCode(
 
     // Server
     INTERNAL_SERVER_ERROR("Internal server error"),
+
+    // Rate limit
+    RATE_LIMIT_EXCEEDED("Too many requests"),
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilter.kt
@@ -1,0 +1,70 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode
+import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Refill
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+
+/**
+ * Per-IP rate limiting for auth endpoints prone to brute-force/abuse.
+ * Buckets are kept in-memory (no Redis in this deployment); this is sufficient
+ * for the current single-instance deployment but won't hold a shared limit
+ * across multiple instances if the service is scaled horizontally.
+ */
+@Component
+class AuthRateLimitFilter(
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+
+    companion object {
+        private val LIMITED_PATHS = mapOf(
+            "/api/v1/auth/registration" to 5L,
+            "/api/v1/auth/nonce" to 10L,
+            "/api/v1/auth/login" to 5L,
+            "/api/v1/auth/refresh" to 10L,
+        )
+        private val WINDOW: Duration = Duration.ofMinutes(1)
+    }
+
+    private val buckets = Caffeine.newBuilder()
+        .expireAfterAccess(Duration.ofMinutes(10))
+        .maximumSize(50_000)
+        .build<String, Bucket>()
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+        !LIMITED_PATHS.containsKey(request.requestURI)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val limit = LIMITED_PATHS.getValue(request.requestURI)
+        val key = "${request.remoteAddr}:${request.requestURI}"
+        val bucket = buckets.get(key) { newBucket(limit) }
+
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        response.status = 429
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        objectMapper.writeValue(response.writer, ErrorResponse(429, ErrorCode.RATE_LIMIT_EXCEEDED))
+    }
+
+    private fun newBucket(limit: Long): Bucket =
+        Bucket.builder()
+            .addLimit(Bandwidth.classic(limit, Refill.greedy(limit, WINDOW)))
+            .build()
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.dogGetDrunk.meetjyou.auth.dev.DevBypassAuthFilter
 import com.dogGetDrunk.meetjyou.auth.jwt.JwtAuthFilter
 import com.dogGetDrunk.meetjyou.common.exception.ErrorCode
 import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
+import com.dogGetDrunk.meetjyou.common.filter.AuthRateLimitFilter
 import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse
@@ -26,6 +27,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val corsConfig: CorsConfig,
     private val jwtAuthFilter: JwtAuthFilter,
+    private val authRateLimitFilter: AuthRateLimitFilter,
     private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>,
     private val objectMapper: ObjectMapper,
 ) {
@@ -92,6 +94,7 @@ class SecurityConfig(
         }
 
         http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+        http.addFilterBefore(authRateLimitFilter, JwtAuthFilter::class.java)
 
         return http.build()
     }

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilterTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilterTest.kt
@@ -1,0 +1,97 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.FilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class AuthRateLimitFilterTest : BehaviorSpec() {
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        given("로그인 엔드포인트에 반복 요청이 들어올 때") {
+            `when`("허용 한도(5회) 이내면") {
+                then("매번 필터 체인을 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(5) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        val response = MockHttpServletResponse()
+
+                        filter.doFilter(request, response, chain)
+                    }
+
+                    passedCount shouldBe 5
+                }
+            }
+
+            `when`("허용 한도(5회)를 초과하면") {
+                then("6번째 요청부터 429를 반환하고 체인을 통과시키지 않는다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    lateinit var lastResponse: MockHttpServletResponse
+                    repeat(6) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        lastResponse = MockHttpServletResponse()
+
+                        filter.doFilter(request, lastResponse, chain)
+                    }
+
+                    passedCount shouldBe 5
+                    lastResponse.status shouldBe 429
+                }
+            }
+
+            `when`("다른 IP에서 요청하면") {
+                then("한도가 소진된 IP와 무관하게 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(5) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        filter.doFilter(request, MockHttpServletResponse(), chain)
+                    }
+
+                    val otherIpRequest = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                    otherIpRequest.remoteAddr = "192.168.0.1"
+                    val otherIpResponse = MockHttpServletResponse()
+                    filter.doFilter(otherIpRequest, otherIpResponse, chain)
+
+                    passedCount shouldBe 6
+                    otherIpResponse.status shouldBe 200
+                }
+            }
+        }
+
+        given("한도 대상이 아닌 경로에 요청이 들어올 때") {
+            `when`("반복 요청해도") {
+                then("항상 필터 체인을 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(20) {
+                        val request = MockHttpServletRequest("GET", "/api/v1/notices")
+                        request.remoteAddr = "127.0.0.1"
+                        filter.doFilter(request, MockHttpServletResponse(), chain)
+                    }
+
+                    passedCount shouldBe 20
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 로그인/nonce/registration/refresh 엔드포인트에 브루트포스 방어 로직이 없어 Bucket4j 기반 토큰 버킷 필터를 추가했다.
- Redis 없이 단일 인스턴스 배포에 맞춰 Caffeine 캐시에 버킷을 저장하는 방식으로 구현했다.
- 제한: login/registration/nonce 분당 5회, refresh 분당 10회. 초과 시 429 응답.

## Test plan
- [x] `AuthRateLimitFilterTest` 추가 (한도 초과 시점, IP별 독립성, 대상 외 경로 미적용 검증)
- [x] `./gradlew test` 전체 통과