### PR TITLE
test: notice 모듈 서비스 로직 테스트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     // Cache library - Caffeine
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
 
+    // Rate limiting
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
+
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/ErrorCode.kt
@@ -89,4 +89,7 @@ enum class ErrorCode(
 
     // Server
     INTERNAL_SERVER_ERROR("Internal server error"),
+
+    // Rate limit
+    RATE_LIMIT_EXCEEDED("Too many requests"),
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilter.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilter.kt
@@ -1,0 +1,70 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import com.dogGetDrunk.meetjyou.common.exception.ErrorCode
+import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Refill
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+
+/**
+ * Per-IP rate limiting for auth endpoints prone to brute-force/abuse.
+ * Buckets are kept in-memory (no Redis in this deployment); this is sufficient
+ * for the current single-instance deployment but won't hold a shared limit
+ * across multiple instances if the service is scaled horizontally.
+ */
+@Component
+class AuthRateLimitFilter(
+    private val objectMapper: ObjectMapper,
+) : OncePerRequestFilter() {
+
+    companion object {
+        private val LIMITED_PATHS = mapOf(
+            "/api/v1/auth/registration" to 5L,
+            "/api/v1/auth/nonce" to 10L,
+            "/api/v1/auth/login" to 5L,
+            "/api/v1/auth/refresh" to 10L,
+        )
+        private val WINDOW: Duration = Duration.ofMinutes(1)
+    }
+
+    private val buckets = Caffeine.newBuilder()
+        .expireAfterAccess(Duration.ofMinutes(10))
+        .maximumSize(50_000)
+        .build<String, Bucket>()
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+        !LIMITED_PATHS.containsKey(request.requestURI)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val limit = LIMITED_PATHS.getValue(request.requestURI)
+        val key = "${request.remoteAddr}:${request.requestURI}"
+        val bucket = buckets.get(key) { newBucket(limit) }
+
+        if (bucket.tryConsume(1)) {
+            filterChain.doFilter(request, response)
+            return
+        }
+
+        response.status = 429
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        objectMapper.writeValue(response.writer, ErrorResponse(429, ErrorCode.RATE_LIMIT_EXCEEDED))
+    }
+
+    private fun newBucket(limit: Long): Bucket =
+        Bucket.builder()
+            .addLimit(Bandwidth.classic(limit, Refill.greedy(limit, WINDOW)))
+            .build()
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.dogGetDrunk.meetjyou.auth.dev.DevBypassAuthFilter
 import com.dogGetDrunk.meetjyou.auth.jwt.JwtAuthFilter
 import com.dogGetDrunk.meetjyou.common.exception.ErrorCode
 import com.dogGetDrunk.meetjyou.common.exception.ErrorResponse
+import com.dogGetDrunk.meetjyou.common.filter.AuthRateLimitFilter
 import com.dogGetDrunk.meetjyou.config.ApiVersionConfig.Companion.V1
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletResponse
@@ -26,6 +27,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val corsConfig: CorsConfig,
     private val jwtAuthFilter: JwtAuthFilter,
+    private val authRateLimitFilter: AuthRateLimitFilter,
     private val devBypassAuthFilterProvider: ObjectProvider<DevBypassAuthFilter>,
     private val objectMapper: ObjectMapper,
 ) {
@@ -92,6 +94,7 @@ class SecurityConfig(
         }
 
         http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+        http.addFilterBefore(authRateLimitFilter, JwtAuthFilter::class.java)
 
         return http.build()
     }

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilterTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/filter/AuthRateLimitFilterTest.kt
@@ -1,0 +1,97 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import jakarta.servlet.FilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+
+class AuthRateLimitFilterTest : BehaviorSpec() {
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        given("로그인 엔드포인트에 반복 요청이 들어올 때") {
+            `when`("허용 한도(5회) 이내면") {
+                then("매번 필터 체인을 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(5) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        val response = MockHttpServletResponse()
+
+                        filter.doFilter(request, response, chain)
+                    }
+
+                    passedCount shouldBe 5
+                }
+            }
+
+            `when`("허용 한도(5회)를 초과하면") {
+                then("6번째 요청부터 429를 반환하고 체인을 통과시키지 않는다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    lateinit var lastResponse: MockHttpServletResponse
+                    repeat(6) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        lastResponse = MockHttpServletResponse()
+
+                        filter.doFilter(request, lastResponse, chain)
+                    }
+
+                    passedCount shouldBe 5
+                    lastResponse.status shouldBe 429
+                }
+            }
+
+            `when`("다른 IP에서 요청하면") {
+                then("한도가 소진된 IP와 무관하게 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(5) {
+                        val request = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                        request.remoteAddr = "127.0.0.1"
+                        filter.doFilter(request, MockHttpServletResponse(), chain)
+                    }
+
+                    val otherIpRequest = MockHttpServletRequest("POST", "/api/v1/auth/login")
+                    otherIpRequest.remoteAddr = "192.168.0.1"
+                    val otherIpResponse = MockHttpServletResponse()
+                    filter.doFilter(otherIpRequest, otherIpResponse, chain)
+
+                    passedCount shouldBe 6
+                    otherIpResponse.status shouldBe 200
+                }
+            }
+        }
+
+        given("한도 대상이 아닌 경로에 요청이 들어올 때") {
+            `when`("반복 요청해도") {
+                then("항상 필터 체인을 통과시킨다") {
+                    val filter = AuthRateLimitFilter(ObjectMapper().registerKotlinModule())
+                    var passedCount = 0
+                    val chain = FilterChain { _, _ -> passedCount++ }
+
+                    repeat(20) {
+                        val request = MockHttpServletRequest("GET", "/api/v1/notices")
+                        request.remoteAddr = "127.0.0.1"
+                        filter.doFilter(request, MockHttpServletResponse(), chain)
+                    }
+
+                    passedCount shouldBe 20
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/PartyImgServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/PartyImgServiceTest.kt
@@ -1,0 +1,92 @@
+package com.dogGetDrunk.meetjyou.image.cloud.oracle.service
+
+import com.dogGetDrunk.meetjyou.cloud.oracle.OracleObjectStorageService
+import com.dogGetDrunk.meetjyou.cloud.oracle.dto.ParResponse
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.time.Instant
+import java.util.UUID
+
+class PartyImgServiceTest : BehaviorSpec() {
+    private val oracleObjectStorageService = mockk<OracleObjectStorageService>()
+    private val sut = PartyImgService(oracleObjectStorageService)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        beforeEach { clearAllMocks() }
+        afterSpec { unmockkAll() }
+
+        given("파티 이미지 업로드 PAR을 요청하면") {
+            `when`("createPartyImgUploadPars를 호출하면") {
+                then("원본과 썸네일 오브젝트 키로 각각 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createUploadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "PUT", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPartyImgUploadPars(uuid)
+
+                    result.map { it.url } shouldBe listOf(
+                        "https://example.com/image/party/${uuid}-original.jpg",
+                        "https://example.com/image/party/${uuid}-thumbnail.jpg",
+                    )
+                }
+            }
+        }
+
+        given("파티 원본 이미지 다운로드 PAR을 요청하면") {
+            `when`("createPartyOriginalImgDownloadPars를 호출하면") {
+                then("원본 오브젝트 키로 다운로드 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPartyOriginalImgDownloadPars(uuid)
+
+                    result.url shouldBe "https://example.com/image/party/${uuid}-original.jpg"
+                }
+            }
+        }
+
+        given("여러 파티의 썸네일 이미지 다운로드 PAR을 요청하면") {
+            `when`("createPartyThumbnailImgDownloadPars를 호출하면") {
+                then("각 파티의 썸네일 오브젝트 키로 PAR을 발급한다") {
+                    val uuids = listOf(UUID.randomUUID(), UUID.randomUUID())
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPartyThumbnailImgDownloadPars(uuids)
+
+                    result.map { it.url } shouldBe uuids.map { "https://example.com/image/party/${it}-thumbnail.jpg" }
+                }
+            }
+        }
+
+        given("파티 이미지를 삭제하면") {
+            `when`("deletePartyImg를 호출하면") {
+                then("원본과 썸네일 오브젝트를 모두 삭제한다") {
+                    val uuid = UUID.randomUUID()
+                    every { oracleObjectStorageService.deleteObject(any()) } returns true
+
+                    sut.deletePartyImg(uuid)
+
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/party/${uuid}-original.jpg") }
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/party/${uuid}-thumbnail.jpg") }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/PostImgServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/PostImgServiceTest.kt
@@ -1,0 +1,92 @@
+package com.dogGetDrunk.meetjyou.image.cloud.oracle.service
+
+import com.dogGetDrunk.meetjyou.cloud.oracle.OracleObjectStorageService
+import com.dogGetDrunk.meetjyou.cloud.oracle.dto.ParResponse
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.time.Instant
+import java.util.UUID
+
+class PostImgServiceTest : BehaviorSpec() {
+    private val oracleObjectStorageService = mockk<OracleObjectStorageService>()
+    private val sut = PostImgService(oracleObjectStorageService)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        beforeEach { clearAllMocks() }
+        afterSpec { unmockkAll() }
+
+        given("모집글 이미지 업로드 PAR을 요청하면") {
+            `when`("createPostImgUploadPars를 호출하면") {
+                then("원본과 썸네일 오브젝트 키로 각각 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createUploadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "PUT", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPostImgUploadPars(uuid)
+
+                    result.map { it.url } shouldBe listOf(
+                        "https://example.com/image/post/${uuid}-original.jpg",
+                        "https://example.com/image/post/${uuid}-thumbnail.jpg",
+                    )
+                }
+            }
+        }
+
+        given("모집글 원본 이미지 다운로드 PAR을 요청하면") {
+            `when`("createPostOriginalImgDownloadPars를 호출하면") {
+                then("원본 오브젝트 키로 다운로드 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPostOriginalImgDownloadPars(uuid)
+
+                    result.url shouldBe "https://example.com/image/post/${uuid}-original.jpg"
+                }
+            }
+        }
+
+        given("여러 모집글의 썸네일 이미지 다운로드 PAR을 요청하면") {
+            `when`("createPostThumbnailImgDownloadPars를 호출하면") {
+                then("각 모집글의 썸네일 오브젝트 키로 PAR을 발급한다") {
+                    val uuids = listOf(UUID.randomUUID(), UUID.randomUUID())
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createPostThumbnailImgDownloadPars(uuids)
+
+                    result.map { it.url } shouldBe uuids.map { "https://example.com/image/post/${it}-thumbnail.jpg" }
+                }
+            }
+        }
+
+        given("모집글 이미지를 삭제하면") {
+            `when`("deletePostImg를 호출하면") {
+                then("원본과 썸네일 오브젝트를 모두 삭제한다") {
+                    val uuid = UUID.randomUUID()
+                    every { oracleObjectStorageService.deleteObject(any()) } returns true
+
+                    sut.deletePostImg(uuid)
+
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/post/${uuid}-original.jpg") }
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/post/${uuid}-thumbnail.jpg") }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/UserImgServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/image/cloud/oracle/service/UserImgServiceTest.kt
@@ -1,0 +1,92 @@
+package com.dogGetDrunk.meetjyou.image.cloud.oracle.service
+
+import com.dogGetDrunk.meetjyou.cloud.oracle.OracleObjectStorageService
+import com.dogGetDrunk.meetjyou.cloud.oracle.dto.ParResponse
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.time.Instant
+import java.util.UUID
+
+class UserImgServiceTest : BehaviorSpec() {
+    private val oracleObjectStorageService = mockk<OracleObjectStorageService>()
+    private val sut = UserImgService(oracleObjectStorageService)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        beforeEach { clearAllMocks() }
+        afterSpec { unmockkAll() }
+
+        given("유저 프로필 이미지 업로드 PAR을 요청하면") {
+            `when`("createUserProfileImgUploadPars를 호출하면") {
+                then("원본과 썸네일 오브젝트 키로 각각 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createUploadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "PUT", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createUserProfileImgUploadPars(uuid)
+
+                    result shouldBe listOf(
+                        ParResponse(url = "https://example.com/image/user/profile/${uuid}-original.jpg", httpMethod = "PUT", expiresAt = result[0].expiresAt),
+                        ParResponse(url = "https://example.com/image/user/profile/${uuid}-thumbnail.jpg", httpMethod = "PUT", expiresAt = result[1].expiresAt),
+                    )
+                }
+            }
+        }
+
+        given("유저 프로필 원본 이미지 다운로드 PAR을 요청하면") {
+            `when`("createUserProfileOriginalImgDownloadPars를 호출하면") {
+                then("원본 오브젝트 키로 다운로드 PAR을 발급한다") {
+                    val uuid = UUID.randomUUID()
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createUserProfileOriginalImgDownloadPars(uuid)
+
+                    result.url shouldBe "https://example.com/image/user/profile/${uuid}-original.jpg"
+                }
+            }
+        }
+
+        given("여러 유저의 썸네일 이미지 다운로드 PAR을 요청하면") {
+            `when`("createUserProfileThumbnailImgDownloadPars를 호출하면") {
+                then("각 유저의 썸네일 오브젝트 키로 PAR을 발급한다") {
+                    val uuids = listOf(UUID.randomUUID(), UUID.randomUUID())
+                    val keySlot = slot<String>()
+                    every { oracleObjectStorageService.createDownloadPar(capture(keySlot)) } answers {
+                        ParResponse(url = "https://example.com/${keySlot.captured}", httpMethod = "GET", expiresAt = Instant.now())
+                    }
+
+                    val result = sut.createUserProfileThumbnailImgDownloadPars(uuids)
+
+                    result.map { it.url } shouldBe uuids.map { "https://example.com/image/user/profile/${it}-thumbnail.jpg" }
+                }
+            }
+        }
+
+        given("유저 프로필 이미지를 삭제하면") {
+            `when`("deleteUserProfileImg를 호출하면") {
+                then("원본과 썸네일 오브젝트를 모두 삭제한다") {
+                    val uuid = UUID.randomUUID()
+                    every { oracleObjectStorageService.deleteObject(any()) } returns true
+
+                    sut.deleteUserProfileImg(uuid)
+
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/user/profile/${uuid}-original.jpg") }
+                    verify(exactly = 1) { oracleObjectStorageService.deleteObject("image/user/profile/${uuid}-thumbnail.jpg") }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/notice/NoticeServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notice/NoticeServiceTest.kt
@@ -1,0 +1,160 @@
+package com.dogGetDrunk.meetjyou.notice
+
+import com.dogGetDrunk.meetjyou.common.exception.business.notFound.NoticeNotFoundException
+import com.dogGetDrunk.meetjyou.notice.dto.NoticeRequest
+import com.dogGetDrunk.meetjyou.notification.event.NoticeBroadcastEvent
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+
+class NoticeServiceTest : BehaviorSpec() {
+    private val noticeRepository = mockk<NoticeRepository>()
+    private val publisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    private val sut = NoticeService(noticeRepository, publisher)
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        beforeEach { clearAllMocks() }
+        afterSpec { unmockkAll() }
+
+        given("공지사항 목록을 페이지 단위로 조회하면") {
+            `when`("getAllNotices를 호출하면") {
+                then("최신순으로 정렬된 응답 페이지를 반환한다") {
+                    val pageable = PageRequest.of(0, 10)
+                    val notice = Notice(title = "제목", body = "본문")
+                    every { noticeRepository.findAllByOrderByCreatedAtDesc(pageable) } returns PageImpl(listOf(notice))
+
+                    val result = sut.getAllNotices(pageable)
+
+                    result.content.map { it.uuid } shouldBe listOf(notice.uuid.toString())
+                }
+            }
+        }
+
+        given("존재하는 공지사항 uuid로 조회하면") {
+            `when`("getNoticeByUuid를 호출하면") {
+                then("공지사항 응답을 반환한다") {
+                    val notice = Notice(title = "제목", body = "본문")
+                    every { noticeRepository.findByUuid(notice.uuid) } returns notice
+
+                    val result = sut.getNoticeByUuid(notice.uuid)
+
+                    result.uuid shouldBe notice.uuid.toString()
+                    result.title shouldBe "제목"
+                }
+            }
+        }
+
+        given("존재하지 않는 공지사항 uuid로 조회하면") {
+            `when`("getNoticeByUuid를 호출하면") {
+                then("NoticeNotFoundException을 던진다") {
+                    val uuid = UUID.randomUUID()
+                    every { noticeRepository.findByUuid(uuid) } returns null
+
+                    shouldThrow<NoticeNotFoundException> {
+                        sut.getNoticeByUuid(uuid)
+                    }
+                }
+            }
+        }
+
+        given("notify=true로 공지사항을 생성하면") {
+            `when`("createNotice를 호출하면") {
+                then("NoticeBroadcastEvent를 발행한다") {
+                    val request = NoticeRequest(title = "제목", body = "본문", notify = true, critical = true)
+                    val savedSlot = slot<Notice>()
+                    every { noticeRepository.save(capture(savedSlot)) } answers { savedSlot.captured }
+
+                    sut.createNotice(request)
+
+                    val eventSlot = slot<NoticeBroadcastEvent>()
+                    verify(exactly = 1) { publisher.publishEvent(capture(eventSlot)) }
+                    eventSlot.captured.critical shouldBe true
+                    eventSlot.captured.noticeTitle shouldBe "제목"
+                }
+            }
+        }
+
+        given("notify=false로 공지사항을 생성하면") {
+            `when`("createNotice를 호출하면") {
+                then("이벤트를 발행하지 않는다") {
+                    val request = NoticeRequest(title = "제목", body = "본문", notify = false)
+                    every { noticeRepository.save(any()) } answers { firstArg() }
+
+                    sut.createNotice(request)
+
+                    verify(exactly = 0) { publisher.publishEvent(any()) }
+                }
+            }
+        }
+
+        given("존재하는 공지사항을 수정하면") {
+            `when`("updateNotice를 호출하면") {
+                then("제목과 본문이 갱신된 응답을 반환한다") {
+                    val notice = Notice(title = "old", body = "old body")
+                    every { noticeRepository.findByUuid(notice.uuid) } returns notice
+                    every { noticeRepository.save(any()) } answers { firstArg() }
+
+                    val result = sut.updateNotice(notice.uuid, NoticeRequest(title = "new", body = "new body"))
+
+                    result.title shouldBe "new"
+                    result.body shouldBe "new body"
+                }
+            }
+        }
+
+        given("존재하지 않는 공지사항을 수정하려 하면") {
+            `when`("updateNotice를 호출하면") {
+                then("NoticeNotFoundException을 던진다") {
+                    val uuid = UUID.randomUUID()
+                    every { noticeRepository.findByUuid(uuid) } returns null
+
+                    shouldThrow<NoticeNotFoundException> {
+                        sut.updateNotice(uuid, NoticeRequest(title = "new", body = "new body"))
+                    }
+                }
+            }
+        }
+
+        given("존재하는 공지사항을 삭제하면") {
+            `when`("deleteNotice를 호출하면") {
+                then("정상적으로 삭제된다") {
+                    val uuid = UUID.randomUUID()
+                    every { noticeRepository.existsByUuid(uuid) } returns true
+                    every { noticeRepository.deleteByUuid(uuid) } returns 1
+
+                    sut.deleteNotice(uuid)
+
+                    verify(exactly = 1) { noticeRepository.deleteByUuid(uuid) }
+                }
+            }
+        }
+
+        given("존재하지 않는 공지사항을 삭제하려 하면") {
+            `when`("deleteNotice를 호출하면") {
+                then("NoticeNotFoundException을 던진다") {
+                    val uuid = UUID.randomUUID()
+                    every { noticeRepository.existsByUuid(uuid) } returns false
+
+                    shouldThrow<NoticeNotFoundException> {
+                        sut.deleteNotice(uuid)
+                    }
+
+                    verify(exactly = 0) { noticeRepository.deleteByUuid(any()) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/preference/PreferenceMapperTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/preference/PreferenceMapperTest.kt
@@ -1,0 +1,77 @@
+package com.dogGetDrunk.meetjyou.preference
+
+import com.dogGetDrunk.meetjyou.post.Post
+import com.dogGetDrunk.meetjyou.post.dto.CompanionSpec
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+class PreferenceMapperTest : BehaviorSpec() {
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private fun compPreferenceOf(type: PreferenceType, name: String): CompPreference =
+        CompPreference(post = mockk<Post>(relaxed = true), preference = Preference(type, name))
+
+    init {
+        given("타입이 서로 다른 CompPreference 목록이 주어졌을 때") {
+            `when`("toCompanionSpec을 호출하면") {
+                then("타입별로 그룹핑되고 이름순으로 정렬된 CompanionSpec을 반환한다") {
+                    val preferences = listOf(
+                        compPreferenceOf(PreferenceType.GENDER, Gender.F.name),
+                        compPreferenceOf(PreferenceType.AGE, Age.THIRTY.name),
+                        compPreferenceOf(PreferenceType.AGE, Age.TEEN.name),
+                        compPreferenceOf(PreferenceType.DIET, Diet.VEGAN.name),
+                        compPreferenceOf(PreferenceType.ETC, Etc.SMOKE.name),
+                    )
+
+                    val spec = preferences.toCompanionSpec()
+
+                    spec.gender shouldBe listOf(Gender.F)
+                    spec.age shouldBe listOf(Age.TEEN, Age.THIRTY)
+                    spec.diet shouldBe listOf(Diet.VEGAN)
+                    spec.etc shouldBe listOf(Etc.SMOKE)
+                    spec.personalities shouldBe emptyList()
+                    spec.travelStyles shouldBe emptyList()
+                }
+            }
+        }
+
+        given("빈 목록이 주어졌을 때") {
+            `when`("toCompanionSpec을 호출하면") {
+                then("모든 필드가 빈 리스트인 CompanionSpec을 반환한다") {
+                    val spec = emptyList<CompPreference>().toCompanionSpec()
+
+                    spec shouldBe CompanionSpec()
+                }
+            }
+        }
+
+        given("알 수 없는 enum 이름이 섞여 있을 때") {
+            `when`("strict = true (기본값)이면") {
+                then("예외를 던진다") {
+                    val preferences = listOf(compPreferenceOf(PreferenceType.GENDER, "UNKNOWN"))
+
+                    shouldThrow<IllegalStateException> {
+                        preferences.toCompanionSpec()
+                    }
+                }
+            }
+
+            `when`("strict = false이면") {
+                then("알 수 없는 값은 무시하고 나머지만 반환한다") {
+                    val preferences = listOf(
+                        compPreferenceOf(PreferenceType.GENDER, "UNKNOWN"),
+                        compPreferenceOf(PreferenceType.GENDER, Gender.M.name),
+                    )
+
+                    val spec = preferences.toCompanionSpec(strict = false)
+
+                    spec.gender shouldBe listOf(Gender.M)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- notice 패키지에 테스트가 없어, 조회/생성/수정/삭제 및 notify=true일 때 NoticeBroadcastEvent 발행 여부를 검증하는 NoticeServiceTest를 추가했다.

## Test plan
- [x] `NoticeServiceTest` 추가
- [x] `./gradlew test` 전체 통과