### PR TITLE
chore: 배포 헬스체크 대기시간 210초 -> 300초로 증가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,9 +103,9 @@ jobs:
             docker-compose pull
             docker-compose up -d
 
-            echo "헬스체크 대기 중... (OCI 프리티어 기동 시간을 고려해 최대 210초 대기)"
+            echo "헬스체크 대기 중... (OCI 프리티어 기동 시간을 고려해 최대 300초 대기)"
             HEALTHY=false
-            for i in $(seq 1 42); do
+            for i in $(seq 1 60); do
               if curl -sf http://127.0.0.1:8081/actuator/health | grep -q '"status":"UP"'; then
                 HEALTHY=true
                 break


### PR DESCRIPTION
## Summary
- N+1 수정(PR #104) 배포 시 헬스체크 타임아웃(210초)으로 자동 롤백됨
- 연속 배포로 인한 OCI 프리티어 콜드스타트 지연 가능성을 고려해 300초로 늘림

🤖 Generated with [Claude Code](https://claude.com/claude-code)