### PR TITLE
fix: 전체 API 감사에서 발견한 치명적 버그 3건 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/auth/refreshtoken/RefreshTokenRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/auth/refreshtoken/RefreshTokenRepository.kt
@@ -1,9 +1,16 @@
 package com.dogGetDrunk.meetjyou.auth.refreshtoken
 
+import com.dogGetDrunk.meetjyou.user.User
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
     fun findByJti(jti: String): RefreshToken?
+
+    @Modifying
+    @Query("update RefreshToken r set r.revoked = true where r.user = :user")
+    fun revokeAllByUser(user: User): Int
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -164,6 +165,26 @@ class GlobalExceptionHandler(
 
         val status = HttpStatus.FORBIDDEN
         val errorResponse = ErrorResponse(status.value(), e.errorCode, e.value)
+        return ResponseEntity(errorResponse, status)
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException::class)
+    fun handleSpringAuthorizationDeniedException(
+        e: AuthorizationDeniedException,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
+        log.info("Handling AuthorizationDeniedException.", e)
+
+        discordAlertService.sendAlert(
+            request = request,
+            status = HttpStatus.FORBIDDEN.value(),
+            exceptionClass = e.javaClass.simpleName,
+            summary = "[${ErrorCode.ACCESS_DENIED.name}] ${ErrorCode.ACCESS_DENIED.message}",
+            detail = null,
+        )
+
+        val status = HttpStatus.FORBIDDEN
+        val errorResponse = ErrorResponse(status.value(), ErrorCode.ACCESS_DENIED)
         return ResponseEntity(errorResponse, status)
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyController.kt
@@ -90,7 +90,7 @@ class PartyController(
     @GetMapping("/plan/{planUuid}")
     fun getPartiesByPlanUuid(
         @PathVariable planUuid: UUID,
-        @ParameterObject @PageableDefault(size = 10, sort = ["party.createdAt"], direction = Sort.Direction.DESC)
+        @ParameterObject @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC)
         pageable: Pageable,
     ): Page<GetPartyResponse> {
         return partyService.getPartiesByPlanUuid(planUuid, pageable)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.dogGetDrunk.meetjyou.user
 
+import com.dogGetDrunk.meetjyou.auth.refreshtoken.RefreshTokenRepository
 import com.dogGetDrunk.meetjyou.auth.social.SocialPrincipal
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.PreferenceNotFoundException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
@@ -28,6 +29,7 @@ class UserService(
     private val userPreferenceRepository: UserPreferenceRepository,
     private val currentUserProvider: CurrentUserProvider,
     private val termsService: TermsService,
+    private val refreshTokenRepository: RefreshTokenRepository,
 ) {
     private val log = LoggerFactory.getLogger(UserService::class.java)
 
@@ -64,14 +66,12 @@ class UserService(
     @Transactional
     fun withdrawUser() {
         val uuid = currentUserProvider.uuid
-        userRepository.findByUuid(uuid) ?: throw UserNotFoundException(uuid)
+        val user = userRepository.findByUuid(uuid) ?: throw UserNotFoundException(uuid)
 
         log.info("Processing user withdrawal (user uuid: {})", uuid)
-        if (userRepository.deleteByUuid(uuid) > 0) {
-            log.info("User withdrawal completed (user uuid: {})", uuid)
-        } else {
-            log.warn("User withdrawal completed with no rows deleted (user uuid: {})", uuid)
-        }
+        user.status = UserStatus.DELETED
+        refreshTokenRepository.revokeAllByUser(user)
+        log.info("User withdrawal completed (user uuid: {})", uuid)
     }
 
     @Transactional

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,30 @@
+package com.dogGetDrunk.meetjyou.common.exception
+
+import com.dogGetDrunk.meetjyou.common.discord.DiscordAlertService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.security.authorization.AuthorizationDeniedException
+import org.springframework.security.authorization.AuthorizationResult
+
+class GlobalExceptionHandlerTest : BehaviorSpec({
+
+    val discordAlertService = mockk<DiscordAlertService>(relaxed = true)
+    val request = mockk<HttpServletRequest>(relaxed = true)
+    val sut = GlobalExceptionHandler(discordAlertService)
+
+    given("@PreAuthorize에 의해 AuthorizationDeniedException이 발생하면") {
+        `when`("handleSpringAuthorizationDeniedException을 호출하면") {
+            then("500이 아닌 403과 ACCESS_DENIED 에러코드를 반환한다") {
+                val exception = AuthorizationDeniedException("Access Denied", mockk<AuthorizationResult>(relaxed = true))
+
+                val response = sut.handleSpringAuthorizationDeniedException(exception, request)
+
+                response.statusCode shouldBe HttpStatus.FORBIDDEN
+                response.body?.errorCode shouldBe ErrorCode.ACCESS_DENIED.name
+            }
+        }
+    }
+})

--- a/src/test/java/com/dogGetDrunk/meetjyou/party/PartyControllerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/party/PartyControllerTest.kt
@@ -1,0 +1,24 @@
+package com.dogGetDrunk.meetjyou.party
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springdoc.core.annotations.ParameterObject
+import org.springframework.data.web.PageableDefault
+
+class PartyControllerTest : BehaviorSpec({
+
+    given("getPartiesByPlanUuid의 기본 페이지네이션 정렬 설정은") {
+        `when`("파라미터를 확인하면") {
+            then("Party 엔티티에 실제로 존재하는 프로퍼티(createdAt)를 가리켜야 한다") {
+                val method = PartyController::class.java.methods
+                    .first { it.name == "getPartiesByPlanUuid" }
+                val pageableParam = method.parameters.first { it.isAnnotationPresent(ParameterObject::class.java) }
+                val sort = pageableParam.getAnnotation(PageableDefault::class.java).sort
+
+                // PartyRepository.findAllByPlan_Uuid queries Party directly, not UserParty,
+                // so the sort property must NOT be prefixed with "party." (copy-paste regression guard).
+                sort shouldBe arrayOf("createdAt")
+            }
+        }
+    }
+})

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/UserServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.dogGetDrunk.meetjyou.user
 
+import com.dogGetDrunk.meetjyou.auth.refreshtoken.RefreshTokenRepository
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
 import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
 import com.dogGetDrunk.meetjyou.preference.PreferenceRepository
@@ -24,6 +25,7 @@ class UserServiceTest : BehaviorSpec() {
 
     private val currentUserProvider = mockk<CurrentUserProvider>(relaxed = true)
     private val termsService = mockk<TermsService>(relaxed = true)
+    private val refreshTokenRepository = mockk<RefreshTokenRepository>(relaxed = true)
 
     private val sut = UserService(
         userRepository,
@@ -31,6 +33,7 @@ class UserServiceTest : BehaviorSpec() {
         userPreferenceRepository,
         currentUserProvider,
         termsService,
+        refreshTokenRepository,
     )
 
     override fun isolationMode() = IsolationMode.InstancePerLeaf
@@ -165,6 +168,35 @@ class UserServiceTest : BehaviorSpec() {
                     val result = sut.getUserProfile(user.uuid)
 
                     result.hasProfileImage shouldBe true
+                }
+            }
+        }
+
+        // ── withdrawUser ─────────────────────────────────────────────────────
+
+        given("withdrawUser 호출 시") {
+            val user = UserFixtures.user()
+
+            beforeEach {
+                every { currentUserProvider.uuid } returns user.uuid
+                every { userRepository.findByUuid(user.uuid) } returns user
+            }
+
+            `when`("post/plan 등 연관 데이터가 있어 하드 삭제라면 FK 위반이 날 상황이어도") {
+                then("하드 삭제 대신 status를 DELETED로 바꾸고 리프레시 토큰을 모두 무효화한다") {
+                    sut.withdrawUser()
+
+                    user.status shouldBe UserStatus.DELETED
+                    verify { refreshTokenRepository.revokeAllByUser(user) }
+                    verify(exactly = 0) { userRepository.deleteByUuid(any()) }
+                }
+            }
+
+            `when`("유저가 존재하지 않으면") {
+                then("UserNotFoundException을 던진다") {
+                    every { userRepository.findByUuid(user.uuid) } returns null
+
+                    shouldThrow<UserNotFoundException> { sut.withdrawUser() }
                 }
             }
         }


### PR DESCRIPTION
## Summary
전체 API 대상 성능/버그 감사(로컬 서버로 실제 재현 확인) 중 발견한, 기능이 완전히 깨진 3건을 수정합니다.

- **`DELETE /users/me`**: plan/post/party를 소유한 유저는 하드 삭제 시 FK 위반으로 500이 나서 탈퇴 자체가 불가능했음. `UserStatus.DELETED`(이미 정의돼 있었지만 미사용)로 소프트 삭제하도록 변경하고, 탈퇴 시 리프레시 토큰을 모두 무효화.
- **`GET /parties/plan/{planUuid}`**: 기본 파라미터로 호출하면 100% 500 (`PropertyReferenceException`) — 다른 엔드포인트에서 복붙된 정렬 프로퍼티(`party.createdAt`)가 이 쿼리 대상(`Party` 자체)에는 존재하지 않음.
- **ADMIN 전용 엔드포인트 권한 거부**: `AuthorizationDeniedException`이 전용 핸들러 없이 catch-all로 떨어져 500이 되던 것을 403 + `ACCESS_DENIED`로 수정.

## Test plan
- [x] `./gradlew test` 전체 219개 통과 (신규 3건 포함)
- [x] 로컬 서버에서 3건 모두 실제 재현 후 수정 확인 (DB의 `user.status`/`refresh_token.revoked` 반영까지 직접 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)