### PR TITLE
perf: N+1 쿼리 수정 + Hikari connection-timeout 단축

### DIFF
--- a/loadtest/full-api-scenario.js
+++ b/loadtest/full-api-scenario.js
@@ -1,0 +1,420 @@
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// Comprehensive load test for meetjyou-backend local dev instance.
+// Covers every REST endpoint that is safe to hit from a local dev DB: auth, user profile,
+// post, plan, marker, party (join/approve/reject), chat (read-side), push-token,
+// notification-center, notice (read-only), terms (read-only), version (read-only).
+//
+// Deliberately EXCLUDED:
+// - OracleObjectStorageController (all /*/img/par/* endpoints) — these call real OCI Object
+//   Storage even under the dev profile (no mock), so they are out of scope for a local test.
+// - Notice/Terms(write)/Version(write) admin endpoints and GET /users (all admin-only,
+//   @PreAuthorize ADMIN) — except addVersion, which setup() calls once to seed a version row
+//   (see below); it never touches OCI, unlike Terms.publishTerms.
+// - Chat message send (ChatController.handleMessage is a STOMP @MessageMapping, not REST —
+//   needs a SockJS/STOMP client, see .claude/rules/chat.md for the integration-test pattern).
+// - PartyController.banMember / deleteParty / leaveParty / completeParty — destructive to the
+//   shared party the VU itself owns and not needed to exercise the read/write paths.
+//
+// KNOWN GAP: PATCH /users/me/marketing-consent 404s on a fresh DB because it requires a
+// published Terms(type=MARKETING_SNS_EVENTS) row, and Terms.publishTerms validates the content
+// was actually uploaded to OCI (hash check) — there's no way to seed it without OCI, so this
+// check is intentionally left accepting 404 rather than treated as a failure.
+//
+// Requires: SPRING_PROFILES_ACTIVE=dev,db,secrets (dev bypass enabled)
+// Run: k6 run loadtest/full-api-scenario.js
+// Override target: k6 run -e BASE_URL=http://localhost:8080 loadtest/full-api-scenario.js
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const ADMIN_PASSPHRASE = __ENV.ADMIN_PASSPHRASE || 'dev-admin-passphrase';
+
+const errorRate = new Rate('errors');
+
+// Per-group latency, so the end-of-test summary shows which section of the journey (not just
+// the overall p95) is disproportionately slow.
+const groupTrends = {
+  'profile setup': new Trend('group_profile_setup_ms'),
+  browse: new Trend('group_browse_ms'),
+  'content creation': new Trend('group_content_creation_ms'),
+  'social interaction': new Trend('group_social_interaction_ms'),
+  'push & chat read': new Trend('group_push_chat_read_ms'),
+  'notification center': new Trend('group_notification_center_ms'),
+};
+
+function timedGroup(name, fn) {
+  const start = Date.now();
+  group(name, fn);
+  groupTrends[name].add(Date.now() - start);
+}
+
+// Seeds an AppVersion(platform=ANDROID, version=1.0.0) row via the admin API so
+// PushTokenController.register (which validates appVersion against this table) doesn't 404
+// on a fresh DB. addVersion is local-DB-only (no OCI call), unlike Terms.publishTerms.
+export function setup() {
+  const unique = `${Date.now()}${Math.floor(Math.random() * 100000)}`;
+  const regRes = http.post(
+    `${BASE_URL}/api/v1/dev/auth/register`,
+    JSON.stringify({ email: `loadtest-setup-${unique}@local.test`, nickname: 'setupadm' }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  if (regRes.status !== 201) {
+    console.warn(`setup: dev register failed (${regRes.status}), version seed skipped`);
+    return {};
+  }
+  const promoteRes = http.post(
+    `${BASE_URL}/api/v1/auth/promote-admin`,
+    JSON.stringify({ passphrase: ADMIN_PASSPHRASE }),
+    { headers: { Authorization: `Bearer ${regRes.json('accessToken')}`, 'Content-Type': 'application/json' } },
+  );
+  if (promoteRes.status !== 200) {
+    console.warn(`setup: promote-admin failed (${promoteRes.status}), version seed skipped`);
+    return {};
+  }
+  const adminToken = promoteRes.json('accessToken');
+  const versionRes = http.post(
+    `${BASE_URL}/api/v1/android/versions`,
+    JSON.stringify({
+      platform: 'ANDROID',
+      version: '1.0.0',
+      forceUpdate: false,
+      message: null,
+      storeReleased: true,
+      releasedAt: '2026-01-01T00:00:00Z',
+    }),
+    { headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' } },
+  );
+  if (![201, 409].includes(versionRes.status)) {
+    console.warn(`setup: addVersion failed (${versionRes.status}): ${versionRes.body}`);
+  }
+  return {};
+}
+
+export const options = {
+  scenarios: {
+    // Main journey: register once per VU, then repeatedly browse/create/interact.
+    full_journey: {
+      executor: 'ramping-vus',
+      exec: 'journey',
+      startVUs: 0,
+      stages: [
+        { duration: '20s', target: 10 },
+        { duration: '40s', target: 10 },
+        { duration: '20s', target: 30 },
+        { duration: '40s', target: 30 },
+        { duration: '20s', target: 50 },
+        { duration: '40s', target: 50 },
+        { duration: '20s', target: 0 },
+      ],
+    },
+    // Separate, low-volume scenario for session lifecycle (refresh/logout/withdraw) so the
+    // main journey VUs don't lose their session mid-test.
+    auth_lifecycle: {
+      executor: 'per-vu-iterations',
+      exec: 'lifecycle',
+      vus: 5,
+      iterations: 3,
+      maxDuration: '3m',
+      startTime: '5s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<800'],
+    errors: ['rate<0.05'],
+  },
+};
+
+const PERSONALITIES = ['INTROVERTED', 'EXTROVERTED', 'SOCIAL', 'OPTIMISTIC', 'FREE', 'PRACTICAL', 'CAREFUL', 'BOLD'];
+const TRAVEL_STYLES = ['ACTIVITY', 'RELAX', 'CULTURE', 'FOOD', 'SPORTS', 'BUDGET', 'LUXURY', 'ADVENTURE', 'NATURE', 'URBAN', 'ART', 'SHOP'];
+const DIETS = ['VEGETARIAN', 'GLUTEN_FREE', 'VEGAN', 'SPECIFIC', 'ANYTHING'];
+const ETCS = ['SMOKE', 'DRINK', 'DONT_CARE'];
+
+function pick(arr, n) {
+  return arr.slice(0, n);
+}
+
+function registerVU(tag) {
+  const unique = `${Date.now()}${Math.floor(Math.random() * 100000)}`;
+  const email = `loadtest-${tag}${__VU}-${unique}@local.test`;
+  const seed = __VU * 1e6 + __ITER * 1000 + Math.floor(Math.random() * 1000);
+  const nickname = `u${seed.toString(36)}`.slice(0, 8);
+  const res = http.post(
+    `${BASE_URL}/api/v1/dev/auth/register`,
+    JSON.stringify({ email, nickname }),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+  check(res, { 'register status 201': (r) => r.status === 201 }) || errorRate.add(1);
+  if (res.status !== 201) return null;
+  const body = res.json();
+  return { uuid: body.uuid, accessToken: body.accessToken, refreshToken: body.refreshToken, nickname };
+}
+
+function authHeaders(session) {
+  return { headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.accessToken}` } };
+}
+
+let vuSession = null;
+let vuState = {}; // ownPostUuid, ownPartyUuid, ownPlanUuid, ownRoomUuid, joinedPartyUuid
+
+export function journey() {
+  if (!vuSession) {
+    vuSession = registerVU('vu');
+    if (!vuSession) {
+      sleep(1);
+      return;
+    }
+  }
+  const h = authHeaders(vuSession);
+
+  timedGroup('profile setup', () => {
+    const dup = http.get(`${BASE_URL}/api/v1/users/is-duplicate-nickname?nickname=${vuSession.nickname}`, h);
+    check(dup, { 'nickname dup check 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+    const updateRes = http.put(
+      `${BASE_URL}/api/v1/users/me`,
+      JSON.stringify({
+        nickname: vuSession.nickname,
+        bio: 'k6 load test bio',
+        gender: 'O',
+        age: 'TWENTY',
+        personalities: pick(PERSONALITIES, 2),
+        travelStyles: pick(TRAVEL_STYLES, 2),
+        diet: pick(DIETS, 1),
+        etc: pick(ETCS, 1),
+      }),
+      h,
+    );
+    check(updateRes, { 'update profile 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+    const consentRes = http.patch(
+      `${BASE_URL}/api/v1/users/me/marketing-consent`,
+      JSON.stringify({ snsConsented: true, emailConsented: false }),
+      h,
+    );
+    // 404 is expected on a DB with no published MARKETING_SNS_EVENTS terms — see KNOWN GAP above.
+    check(consentRes, { 'marketing consent 204/404(no terms seeded)': (r) => r.status === 204 || r.status === 404 }) || errorRate.add(1);
+
+    const settingsGet = http.get(`${BASE_URL}/api/v1/users/me/notification-settings`, h);
+    check(settingsGet, { 'get notification settings 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+    const settingsPut = http.put(
+      `${BASE_URL}/api/v1/users/me/notification-settings`,
+      JSON.stringify({ globalEnabled: true, categories: null }),
+      h,
+    );
+    check(settingsPut, { 'update notification settings 204': (r) => r.status === 204 }) || errorRate.add(1);
+
+    const myProfile = http.get(`${BASE_URL}/api/v1/users/me/profile`, h);
+    check(myProfile, { 'my profile ok or preference-missing': (r) => r.status === 200 || r.status === 404 }) || errorRate.add(1);
+  });
+
+  sleep(Math.random() * 1);
+
+  timedGroup('browse', () => {
+    const listPosts = http.get(`${BASE_URL}/api/v1/posts?page=0&size=20`, h);
+    check(listPosts, { 'list posts 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+    check(http.get(`${BASE_URL}/api/v1/users/me/posts`, h), { 'my posts 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/plans`, h), { 'my plans 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/parties`, h), { 'my parties 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/applications`, h), { 'my applications 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/chat/rooms`, h), { 'list chat rooms 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/notices?page=0&size=10`, h), { 'list notices 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/terms/active`, h), { 'active terms 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/android/versions/latest`, h), { 'latest version 200/404': (r) => r.status === 200 || r.status === 404 }) || errorRate.add(1);
+
+    if (vuSession.uuid) {
+      check(http.get(`${BASE_URL}/api/v1/users/${vuSession.uuid}/basic-info`, h), { 'basic-info 200': (r) => r.status === 200 }) || errorRate.add(1);
+      check(http.get(`${BASE_URL}/api/v1/users/${vuSession.uuid}/advanced-info`, h), { 'advanced-info 200': (r) => r.status === 200 }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 1);
+
+  timedGroup('content creation', () => {
+    const postPayload = JSON.stringify({
+      title: `k6 trip ${__VU}`.slice(0, 20),
+      content: 'Generated by k6 full-api load test',
+      isInstant: false,
+      itinStart: '2026-08-01T00:00:00Z',
+      itinFinish: '2026-08-05T00:00:00Z',
+      location: '제주',
+      capacity: 4,
+    });
+    const postRes = http.post(`${BASE_URL}/api/v1/posts`, postPayload, h);
+    check(postRes, { 'create post 200': (r) => r.status === 200 }) || errorRate.add(1);
+    if (postRes.status === 200) {
+      const body = postRes.json();
+      vuState.ownPostUuid = body.uuid;
+      vuState.ownRoomUuid = body.chatRoom && body.chatRoom.uuid;
+
+      const detail = http.get(`${BASE_URL}/api/v1/posts/${vuState.ownPostUuid}`, h);
+      check(detail, { 'get own post 200': (r) => r.status === 200 }) || errorRate.add(1);
+      if (detail.status === 200) vuState.ownPartyUuid = detail.json('partyUuid');
+
+      const updatePostRes = http.put(
+        `${BASE_URL}/api/v1/posts/${vuState.ownPostUuid}`,
+        JSON.stringify({
+          title: `k6 trip ${__VU} v2`.slice(0, 20),
+          content: 'Updated by k6 full-api load test',
+          isInstant: false,
+          itinStart: '2026-08-01T00:00:00Z',
+          itinFinish: '2026-08-06T00:00:00Z',
+          location: '제주',
+          capacity: 4,
+        }),
+        h,
+      );
+      check(updatePostRes, { 'update post 200': (r) => r.status === 200 }) || errorRate.add(1);
+    }
+
+    const planPayload = JSON.stringify({
+      title: `k6 plan ${__VU}`.slice(0, 20),
+      itinStart: '2026-08-01T00:00:00Z',
+      itinFinish: '2026-08-05T00:00:00Z',
+      location: '제주',
+      centerLat: 33.4996,
+      centerLng: 126.5312,
+      markers: [],
+    });
+    const planRes = http.post(`${BASE_URL}/api/v1/plans`, planPayload, h);
+    check(planRes, { 'create plan 200': (r) => r.status === 200 }) || errorRate.add(1);
+    if (planRes.status === 200) {
+      vuState.ownPlanUuid = planRes.json('uuid');
+
+      const replaceMarkersRes = http.put(
+        `${BASE_URL}/api/v1/plans/${vuState.ownPlanUuid}/markers`,
+        JSON.stringify({
+          markers: [
+            { lat: 33.5, lng: 126.53, date: '2026-08-01T00:00:00Z', dayNum: 1, idx: 0, place: '공항', memo: null },
+          ],
+        }),
+        h,
+      );
+      check(replaceMarkersRes, { 'replace markers 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+      check(http.get(`${BASE_URL}/api/v1/plans/${vuState.ownPlanUuid}/markers`, h), { 'get markers 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+      const updatePlanRes = http.put(
+        `${BASE_URL}/api/v1/plans/${vuState.ownPlanUuid}`,
+        JSON.stringify({
+          title: `k6 plan ${__VU} v2`.slice(0, 20),
+          itinStart: '2026-08-01T00:00:00Z',
+          itinFinish: '2026-08-06T00:00:00Z',
+          location: '제주',
+          centerLat: 33.4996,
+          centerLng: 126.5312,
+          memo: 'updated',
+          favorite: true,
+        }),
+        h,
+      );
+      check(updatePlanRes, { 'update plan 200': (r) => r.status === 200 }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 1);
+
+  timedGroup('social interaction', () => {
+    // Try to find someone else's post to apply to.
+    const listRes = http.get(`${BASE_URL}/api/v1/posts?page=0&size=20`, h);
+    if (listRes.status === 200) {
+      const content = listRes.json('content') || [];
+      const other = content.find((p) => p.authorUuid !== vuSession.uuid);
+      if (other) {
+        const joinRes = http.post(
+          `${BASE_URL}/api/v1/parties/${other.partyUuid}/join-requests`,
+          JSON.stringify({ applicationNote: 'k6 load test application' }),
+          h,
+        );
+        check(joinRes, { 'join request 201/400/409': (r) => [201, 400, 409].includes(r.status) }) || errorRate.add(1);
+      }
+    }
+
+    if (vuState.ownPartyUuid) {
+      check(http.get(`${BASE_URL}/api/v1/parties/${vuState.ownPartyUuid}/members`, h), { 'party members 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+      const pendingRes = http.get(`${BASE_URL}/api/v1/parties/${vuState.ownPartyUuid}/join-requests`, h);
+      check(pendingRes, { 'pending join requests 200': (r) => r.status === 200 }) || errorRate.add(1);
+      if (pendingRes.status === 200) {
+        const pending = pendingRes.json('requests') || [];
+        if (Array.isArray(pending) && pending.length > 0 && pending[0].userUuid) {
+          const approveRes = http.post(
+            `${BASE_URL}/api/v1/parties/${vuState.ownPartyUuid}/join-requests/${pending[0].userUuid}/approve`,
+            null,
+            h,
+          );
+          check(approveRes, { 'approve join request 204/404': (r) => r.status === 204 || r.status === 404 }) || errorRate.add(1);
+        }
+      }
+    }
+  });
+
+  sleep(Math.random() * 1);
+
+  timedGroup('push & chat read', () => {
+    const token = `k6-fake-token-${__VU}-${__ITER}-${Math.floor(Math.random() * 1e6)}`;
+    const registerPush = http.post(
+      `${BASE_URL}/api/v1/push-tokens`,
+      JSON.stringify({ token, platform: 'ANDROID', appVersion: '1.0.0', deviceModel: 'k6-virtual' }),
+      h,
+    );
+    check(registerPush, { 'register push token 200': (r) => r.status === 200 }) || errorRate.add(1);
+
+    const deactivatePush = http.del(`${BASE_URL}/api/v1/push-tokens?token=${encodeURIComponent(token)}`, null, h);
+    check(deactivatePush, { 'deactivate push token 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+
+    if (vuState.ownRoomUuid) {
+      check(http.get(`${BASE_URL}/api/v1/chat/rooms/${vuState.ownRoomUuid}/messages`, h), { 'chat messages 200': (r) => r.status === 200 }) || errorRate.add(1);
+      check(http.get(`${BASE_URL}/api/v1/chat/rooms/${vuState.ownRoomUuid}/unread-count`, h), { 'unread count 200': (r) => r.status === 200 }) || errorRate.add(1);
+      check(http.post(`${BASE_URL}/api/v1/chat/rooms/${vuState.ownRoomUuid}/read`, null, h), { 'mark as read 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 1);
+
+  timedGroup('notification center', () => {
+    check(http.get(`${BASE_URL}/api/v1/notification-center/notices`, h), { 'nc notices 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.post(`${BASE_URL}/api/v1/notification-center/notices/read`, null, h), { 'nc notices read 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/notification-center/received-applications`, h), { 'nc received 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.post(`${BASE_URL}/api/v1/notification-center/received-applications/read`, null, h), { 'nc received read 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/notification-center/sent-applications`, h), { 'nc sent 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.post(`${BASE_URL}/api/v1/notification-center/sent-applications/read`, null, h), { 'nc sent read 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+  });
+
+  sleep(Math.random() * 1.5);
+}
+
+// Exercises the token lifecycle in isolation: register -> refresh -> logout, then a fresh
+// registration -> withdraw. Kept separate from `journey` so it doesn't invalidate a session
+// mid-scenario for the main VUs.
+export function lifecycle() {
+  const session = registerVU('life');
+  if (!session) {
+    sleep(1);
+    return;
+  }
+
+  const refreshRes = http.post(`${BASE_URL}/api/v1/auth/refresh`, null, {
+    headers: { Authorization: `Bearer ${session.refreshToken}` },
+  });
+  check(refreshRes, { 'refresh 200': (r) => r.status === 200 }) || errorRate.add(1);
+  const refreshed = refreshRes.status === 200 ? refreshRes.json() : session;
+
+  const logoutRes = http.post(`${BASE_URL}/api/v1/auth/logout`, null, {
+    headers: { Authorization: `Bearer ${refreshed.refreshToken}` },
+  });
+  check(logoutRes, { 'logout 204': (r) => r.status === 204 }) || errorRate.add(1);
+
+  sleep(0.5);
+
+  // Separate throwaway session to test withdrawal (soft delete) without affecting the one above.
+  const churnSession = registerVU('churn');
+  if (churnSession) {
+    const withdrawRes = http.del(`${BASE_URL}/api/v1/users/me`, null, authHeaders(churnSession));
+    check(withdrawRes, { 'withdraw 200/204': (r) => r.status === 200 || r.status === 204 }) || errorRate.add(1);
+  }
+
+  sleep(1);
+}

--- a/loadtest/prod-full-read-scenario.js
+++ b/loadtest/prod-full-read-scenario.js
@@ -1,0 +1,198 @@
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate } from 'k6/metrics';
+import encoding from 'k6/encoding';
+
+// Full READ-ONLY sweep of the real production instance (meetjyou.duckdns.org).
+// Covers every GET endpoint reachable by a normal authenticated user, plus the permitAll
+// public GETs — replacing prod-posts-read.js (which only covered GET /posts) as the "full API"
+// read-only baseline for production.
+//
+// Auth: uses the synthetic load-test account via POST /internal/load-test-token
+// (LoadTestTokenController — gated by X-Load-Test-Secret, must be enabled + configured in
+// production secrets). This avoids needing a real Kakao/Google OAuth login in the release
+// profile. The synthetic account has no pre-existing posts/plans/parties/chat rooms unless a
+// prior run created them, so UUID-scoped endpoints are exercised opportunistically (UUIDs
+// discovered from list responses) and checks accept 403/404 as legitimate non-error outcomes,
+// not just 200.
+//
+// Deliberately EXCLUDED (this is a read-only pass by explicit decision, not full coverage):
+// - Every write endpoint (POST/PUT/PATCH/DELETE) — avoids polluting production data or
+//   triggering real push notifications / OCI writes.
+// - All OracleObjectStorageController PAR endpoints and GET /terms/{uuid}/content-url — these
+//   generate real OCI PAR URLs even on a GET, so out of scope (same exclusion as the local
+//   full-api-scenario.js).
+// - Every ADMIN-only GET: GET /users, GET /parties, GET /parties/user/{uuid}, GET
+//   /parties/plan/{uuid}, GET /parties/{uuid} (admin single lookup), GET /plans/user/{uuid},
+//   GET /{platform}/versions (list-all). Reaching these would require promoting the synthetic
+//   account to ADMIN in production — a real, hard-to-reverse privilege change on a live
+//   environment — so it is not done here.
+// - Chat message send (STOMP, not REST — see .claude/rules/chat.md).
+//
+// Run: k6 run -e SECRET=<LOAD_TEST_TOKEN_SECRET> loadtest/prod-full-read-scenario.js
+// Override target: k6 run -e BASE_URL=... -e SECRET=... loadtest/prod-full-read-scenario.js
+
+const BASE_URL = __ENV.BASE_URL || 'https://meetjyou.duckdns.org';
+const SECRET = __ENV.SECRET;
+
+const errorRate = new Rate('errors');
+
+export const options = {
+  scenarios: {
+    read_sweep: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '20s', target: 10 },
+        { duration: '40s', target: 10 },
+        { duration: '20s', target: 30 },
+        { duration: '40s', target: 30 },
+        { duration: '20s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<800'],
+    errors: ['rate<0.05'],
+  },
+};
+
+// LoadTestTokenResponse only carries {accessToken, expiresAt} — no uuid field. The synthetic
+// account's uuid lives in the JWT's own "userUuid" claim (JwtProvider.generateAccessToken),
+// not the subject (which is the email), so it has to be decoded out of the token itself.
+function decodeJwtUuid(token) {
+  const payload = token.split('.')[1];
+  const claims = JSON.parse(encoding.b64decode(payload, 'rawurl', 's'));
+  return claims.userUuid;
+}
+
+// Fetch the synthetic-account token once in setup() and share it across all VUs — the token
+// endpoint issues a fixed-identity JWT and there is no reason for every VU to mint its own.
+export function setup() {
+  const res = http.post(`${BASE_URL}/api/v1/internal/load-test-token`, null, {
+    headers: { 'X-Load-Test-Secret': SECRET },
+  });
+  if (res.status !== 200) {
+    throw new Error(`Failed to obtain load-test token: ${res.status} ${res.body}`);
+  }
+  const body = res.json();
+  const uuid = decodeJwtUuid(body.accessToken);
+  if (!uuid) {
+    throw new Error('Failed to decode userUuid claim from load-test token — aborting to avoid null-path requests.');
+  }
+  return { token: body.accessToken, uuid };
+}
+
+export default function (data) {
+  const h = { headers: { Authorization: `Bearer ${data.token}` } };
+
+  group('public (no auth)', () => {
+    const notices = http.get(`${BASE_URL}/api/v1/notices?page=0&size=20`);
+    check(notices, { 'list notices 200': (r) => r.status === 200 }) || errorRate.add(1);
+    const noticeList = notices.status === 200 ? notices.json('content') || [] : [];
+    if (noticeList.length > 0) {
+      check(http.get(`${BASE_URL}/api/v1/notices/${noticeList[0].uuid}`), { 'notice detail 200': (r) => r.status === 200 }) ||
+        errorRate.add(1);
+    }
+
+    check(http.get(`${BASE_URL}/api/v1/terms/active`), { 'active terms 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/android/versions/check?clientVersion=1.0.0`), {
+      'version check 200/400': (r) => r.status === 200 || r.status === 400,
+    }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/android/versions/latest`), { 'latest version 200/404': (r) => r.status === 200 || r.status === 404 }) ||
+      errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/is-duplicate-nickname?nickname=k6probe${__VU}${__ITER}`), {
+      'nickname dup check 200': (r) => r.status === 200,
+    }) || errorRate.add(1);
+  });
+
+  sleep(Math.random() * 0.5);
+
+  group('user profile (auth)', () => {
+    check(http.get(`${BASE_URL}/api/v1/users/me/profile`, h), { 'my profile 200/404': (r) => r.status === 200 || r.status === 404 }) ||
+      errorRate.add(1);
+    // 404 PREFERENCE_NOT_FOUND is expected here: the synthetic account never goes through
+    // PUT /users/me, so it has no gender/age/etc. preference rows.
+    check(http.get(`${BASE_URL}/api/v1/users/${data.uuid}/basic-info`, h), { 'basic-info 200/404': (r) => r.status === 200 || r.status === 404 }) ||
+      errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/${data.uuid}/advanced-info`, h), { 'advanced-info 200/404': (r) => r.status === 200 || r.status === 404 }) ||
+      errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/plans`, h), { 'my plans 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/parties`, h), { 'my parties 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/applications`, h), { 'my applications 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/posts`, h), { 'my posts 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/users/me/notification-settings`, h), { 'notification settings 200': (r) => r.status === 200 }) ||
+      errorRate.add(1);
+  });
+
+  sleep(Math.random() * 0.5);
+
+  let samplePost = null;
+  group('posts (auth)', () => {
+    const list = http.get(`${BASE_URL}/api/v1/posts?page=0&size=20`, h);
+    check(list, { 'list posts 200': (r) => r.status === 200 }) || errorRate.add(1);
+    const content = list.status === 200 ? list.json('content') || [] : [];
+    if (content.length > 0) samplePost = content[0];
+
+    check(http.get(`${BASE_URL}/api/v1/posts/author/${data.uuid}`, h), { 'posts by author 200': (r) => r.status === 200 }) ||
+      errorRate.add(1);
+
+    if (samplePost) {
+      check(http.get(`${BASE_URL}/api/v1/posts/${samplePost.uuid}`, h), { 'post detail 200': (r) => r.status === 200 }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 0.5);
+
+  group('plan (auth, best-effort)', () => {
+    // Only exercised when a listed post happens to carry a public planUuid — the synthetic
+    // account owns no plans of its own, and there is no plan-listing endpoint to discover one.
+    if (samplePost && samplePost.planUuid) {
+      check(http.get(`${BASE_URL}/api/v1/plans/${samplePost.planUuid}`, h), { 'plan detail 200/403/404': (r) => [200, 403, 404].includes(r.status) }) ||
+        errorRate.add(1);
+      check(http.get(`${BASE_URL}/api/v1/plans/${samplePost.planUuid}/markers`, h), {
+        'plan markers 200/403/404': (r) => [200, 403, 404].includes(r.status),
+      }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 0.5);
+
+  group('party (auth, best-effort)', () => {
+    if (samplePost && samplePost.partyUuid) {
+      check(http.get(`${BASE_URL}/api/v1/parties/${samplePost.partyUuid}/members`, h), {
+        'party members 200/403/404': (r) => [200, 403, 404].includes(r.status),
+      }) || errorRate.add(1);
+      check(http.get(`${BASE_URL}/api/v1/parties/${samplePost.partyUuid}/join-requests`, h), {
+        'pending join-requests 200/403/404': (r) => [200, 403, 404].includes(r.status),
+      }) || errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 0.5);
+
+  group('chat (auth)', () => {
+    const rooms = http.get(`${BASE_URL}/api/v1/chat/rooms`, h);
+    check(rooms, { 'list chat rooms 200': (r) => r.status === 200 }) || errorRate.add(1);
+    const roomList = rooms.status === 200 ? rooms.json('rooms') || [] : [];
+    if (Array.isArray(roomList) && roomList.length > 0 && roomList[0].roomUuid) {
+      const roomUuid = roomList[0].roomUuid;
+      check(http.get(`${BASE_URL}/api/v1/chat/rooms/${roomUuid}/messages`, h), { 'chat messages 200': (r) => r.status === 200 }) ||
+        errorRate.add(1);
+      check(http.get(`${BASE_URL}/api/v1/chat/rooms/${roomUuid}/unread-count`, h), { 'unread count 200': (r) => r.status === 200 }) ||
+        errorRate.add(1);
+    }
+  });
+
+  sleep(Math.random() * 0.5);
+
+  group('notification center (auth)', () => {
+    check(http.get(`${BASE_URL}/api/v1/notification-center/notices`, h), { 'nc notices 200': (r) => r.status === 200 }) || errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/notification-center/received-applications`, h), { 'nc received 200': (r) => r.status === 200 }) ||
+      errorRate.add(1);
+    check(http.get(`${BASE_URL}/api/v1/notification-center/sent-applications`, h), { 'nc sent 200': (r) => r.status === 200 }) ||
+      errorRate.add(1);
+  });
+
+  sleep(1 + Math.random());
+}

--- a/loadtest/prod-posts-read.js
+++ b/loadtest/prod-posts-read.js
@@ -1,0 +1,52 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+// Read-focused benchmark for the real OCI production instance.
+// Purpose: measure GET /api/v1/posts latency before/after the N+1 fix, using the
+// dedicated synthetic load-test-token account. Kept read-only and modest VU count
+// out of respect for OCI free-tier resources (HikariCP pool size 5, shared compute).
+//
+// Run: k6 run -e SECRET=<LOAD_TEST_TOKEN_SECRET> loadtest/prod-posts-read.js
+
+const BASE_URL = __ENV.BASE_URL || 'https://meetjyou.duckdns.org';
+const SECRET = __ENV.SECRET;
+
+export const options = {
+  scenarios: {
+    ramping_read: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '20s', target: 10 },
+        { duration: '40s', target: 10 },
+        { duration: '20s', target: 30 },
+        { duration: '40s', target: 30 },
+        { duration: '20s', target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+// Fetch the token once in setup() and share it across all VUs — the token endpoint
+// is intentionally rate-limited (5/min), so per-VU fetching would exhaust it immediately.
+export function setup() {
+  const res = http.post(`${BASE_URL}/api/v1/internal/load-test-token`, null, {
+    headers: { 'X-Load-Test-Secret': SECRET },
+  });
+  if (res.status !== 200) {
+    throw new Error(`Failed to obtain load-test token: ${res.status} ${res.body}`);
+  }
+  return { token: res.json('accessToken') };
+}
+
+export default function (data) {
+  const authHeaders = { headers: { Authorization: `Bearer ${data.token}` } };
+
+  const res = http.get(`${BASE_URL}/api/v1/posts?page=0&size=10`, authHeaders);
+  check(res, { 'list posts 200': (r) => r.status === 200 });
+
+  sleep(1 + Math.random());
+}

--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
@@ -13,6 +13,7 @@ import com.dogGetDrunk.meetjyou.common.exception.business.chat.ChatRoomAccessDen
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.ChatRoomNotFoundException
 import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
 import com.dogGetDrunk.meetjyou.userparty.MemberStatus
+import com.dogGetDrunk.meetjyou.userparty.UserParty
 import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
@@ -166,6 +167,7 @@ class ChatReadService(
         val partyByUuid = memberships.associate { membership ->
             membership.party.uuid to membership.party
         }
+        val membershipByPartyUuid = memberships.associateBy { it.party.uuid }
 
         val rooms = chatRoomRepository.findAllWithPartyByPartyUuidIn(partyByUuid.keys)
         val roomUuidToPartyUuid = rooms.associate { it.uuid to it.party.uuid }
@@ -180,6 +182,7 @@ class ChatReadService(
 
         val unreadCountByRoomUuid = buildUnreadCountMap(
             roomUuidToPartyUuid = roomUuidToPartyUuid,
+            membershipByPartyUuid = membershipByPartyUuid,
             requesterUuid = requesterUuid,
         )
 
@@ -211,19 +214,12 @@ class ChatReadService(
 
     private fun buildUnreadCountMap(
         roomUuidToPartyUuid: Map<UUID, UUID>,
+        membershipByPartyUuid: Map<UUID, UserParty>,
         requesterUuid: UUID,
     ): Map<UUID, Long> {
         if (roomUuidToPartyUuid.isEmpty()) {
             return emptyMap()
         }
-
-        val partyUuids = roomUuidToPartyUuid.values.toSet()
-
-        val membershipByPartyUuid = userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(
-            userUuid = requesterUuid,
-            memberStatus = MemberStatus.JOINED,
-        ).filter { it.party.uuid in partyUuids }
-            .associateBy { it.party.uuid }
 
         val roomUuidsWithoutLastReadMessageId = roomUuidToPartyUuid
             .filterValues { partyUuid -> membershipByPartyUuid[partyUuid]?.lastReadMessageId == null }
@@ -330,17 +326,42 @@ class ChatReadService(
             return
         }
 
+        val partyUuid = chatRoomRepository.findPartyUuidByRoomUuid(roomUuid) ?: run {
+            log.debug("Read position batch update skipped - room not found. roomUuid={}", roomUuid)
+            return
+        }
+
+        val membershipByUserUuid = userPartyRepository.findAllByParty_UuidAndUser_UuidIn(partyUuid, userUuids)
+            .associateBy { it.user.uuid }
+
         userUuids.forEach { userUuid ->
-            runCatching {
-                updateLastReadPosition(roomUuid, userUuid, messageId)
-            }.onFailure { throwable ->
-                log.debug(
-                    "Read position update skipped. roomUuid={}, userUuid={}, reason={}",
-                    roomUuid,
-                    userUuid,
-                    throwable.message,
-                )
-            }
+            updateMembershipReadPosition(roomUuid, partyUuid, membershipByUserUuid[userUuid], userUuid, messageId)
+        }
+    }
+
+    private fun updateMembershipReadPosition(
+        roomUuid: UUID,
+        partyUuid: UUID,
+        membership: UserParty?,
+        userUuid: UUID,
+        messageId: Long,
+    ) {
+        if (membership == null || !membership.isActiveMember()) {
+            log.debug("Read position update skipped. roomUuid={}, userUuid={}", roomUuid, userUuid)
+            return
+        }
+
+        val previousLastReadMessageId = membership.lastReadMessageId
+        membership.updateLastReadMessageId(messageId)
+
+        if (membership.lastReadMessageId != null && membership.lastReadMessageId != previousLastReadMessageId) {
+            chatRoomEventBroadcaster.broadcastChatReadUpdated(
+                roomUuid = roomUuid,
+                partyUuid = partyUuid,
+                readerUserUuid = userUuid,
+                previousLastReadMessageId = previousLastReadMessageId,
+                currentLastReadMessageId = membership.lastReadMessageId!!,
+            )
         }
     }
 

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcher.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcher.kt
@@ -37,9 +37,11 @@ class NotificationDispatcher(
         // status changed to SENDING within the same transaction to prevent duplicate dispatch
         outboxRepository.bulkUpdateStatus(items.map { it.id }, DeliveryStatus.SENDING)
 
+        val tokensByUserId = targetResolver.resolveUserTargets(items.map { it.user.id }.distinct())
+
         for (item in items) {
             try {
-                processItem(item)
+                processItem(item, tokensByUserId[item.user.id] ?: emptyList())
             } catch (e: Exception) {
                 log.error("Failed to process outbox item id={}, marking PENDING for retry", item.id, e)
                 mark(item, DeliveryStatus.PENDING, item.attempts, item.availableAt)
@@ -55,8 +57,7 @@ class NotificationDispatcher(
         }
     }
 
-    private fun processItem(item: NotificationOutbox) {
-        val tokens = targetResolver.resolveUserTargets(item.user.id)
+    private fun processItem(item: NotificationOutbox, tokens: List<String>) {
         if (tokens.isEmpty()) {
             mark(item, DeliveryStatus.SENT, item.attempts + 1, item.availableAt) // no push tokens registered — no recipients to deliver to, mark as sent
             log.info("No tokens for userId={}, mark SENT. outboxId={}", item.user.id, item.id)

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/push/PushTokenRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query
 
 interface PushTokenRepository : JpaRepository<PushToken, Long> {
     fun findAllByUserIdAndActiveTrue(userId: Long): List<PushToken>
+    fun findAllByUserIdInAndActiveTrue(userIds: Collection<Long>): List<PushToken>
     fun findByToken(token: String): PushToken?
 
     @Query("select count(pt) > 0 from PushToken pt where pt.user.id = :userId and pt.token = :token")

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/target/DefaultNotificationTargetResolver.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/target/DefaultNotificationTargetResolver.kt
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Component
 class DefaultNotificationTargetResolver(
     private val pushTokenRepository: PushTokenRepository,
 ) : NotificationTargetResolver {
-    override fun resolveUserTargets(userId: Long): List<String> {
-        return pushTokenRepository.findAllByUserIdAndActiveTrue(userId).map { it.token }
+    override fun resolveUserTargets(userIds: Collection<Long>): Map<Long, List<String>> {
+        if (userIds.isEmpty()) return emptyMap()
+        return pushTokenRepository.findAllByUserIdInAndActiveTrue(userIds)
+            .groupBy({ it.user.id }, { it.token })
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/notification/target/NotificationTargetResolver.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notification/target/NotificationTargetResolver.kt
@@ -1,5 +1,5 @@
 package com.dogGetDrunk.meetjyou.notification.target
 
 interface NotificationTargetResolver {
-    fun resolveUserTargets(userId: Long): List<String>
+    fun resolveUserTargets(userIds: Collection<Long>): Map<Long, List<String>>
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterService.kt
@@ -52,15 +52,11 @@ class NotificationCenterService(
     @Transactional(readOnly = true)
     fun getReceivedApplications(pageable: Pageable): ReceivedApplicationsSectionResponse {
         val userUuid = currentUserProvider.uuid
-        val allPending = userPartyRepository.findAllPendingRequestsForHost(userUuid)
-        val unreadCount = allPending.count { !it.hostRead }
-        val totalCount = allPending.size.toLong()
-        val paged = allPending
-            .drop(pageable.pageNumber * pageable.pageSize)
-            .take(pageable.pageSize)
-        val partyUuids = paged.map { it.party.uuid }
+        val unreadCount = userPartyRepository.countUnreadPendingRequestsForHost(userUuid)
+        val page = userPartyRepository.findAllPendingRequestsForHost(userUuid, pageable)
+        val partyUuids = page.content.map { it.party.uuid }
         val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
-        val items = paged.map { up ->
+        val items = page.content.map { up ->
             ReceivedApplicationItem(
                 userUuid = up.user.uuid,
                 nickname = up.user.nickname,
@@ -73,7 +69,7 @@ class NotificationCenterService(
                 read = up.hostRead,
             )
         }
-        return ReceivedApplicationsSectionResponse(unreadCount = unreadCount, totalCount = totalCount, applications = items)
+        return ReceivedApplicationsSectionResponse(unreadCount = unreadCount.toInt(), totalCount = page.totalElements, applications = items)
     }
 
     @Transactional
@@ -86,8 +82,12 @@ class NotificationCenterService(
 
     @Transactional(readOnly = true)
     fun getSentApplications(pageable: Pageable): SentApplicationsSectionResponse {
-        val allApplications = userPartyRepository.findAllSentApplicationsByUserUuid(currentUserProvider.uuid)
-        val allItems = allApplications.map { up ->
+        val userUuid = currentUserProvider.uuid
+        val pendingCount = userPartyRepository.countPendingSentApplications(userUuid)
+        val changedCount = userPartyRepository.countChangedUnreadSentApplications(userUuid)
+        val page = userPartyRepository.findAllSentApplicationsByUserUuid(userUuid, pageable)
+
+        val items = page.content.map { up ->
             val status = when (up.memberStatus) {
                 MemberStatus.JOINED    -> ApplicationStatus.ACCEPTED
                 MemberStatus.REJECTED  -> ApplicationStatus.REJECTED
@@ -108,16 +108,15 @@ class NotificationCenterService(
                 read = read,
             )
         }
-        val pendingCount = allItems.count { it.status == ApplicationStatus.PENDING }
-        val changedCount = allItems.count { it.status != ApplicationStatus.PENDING && !it.read }
-        val totalCount = allItems.size.toLong()
-        val paged = allItems
-            .drop(pageable.pageNumber * pageable.pageSize)
-            .take(pageable.pageSize)
-        val partyUuids = paged.map { it.partyUuid }
+        val partyUuids = items.map { it.partyUuid }
         val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }
-        val pagedWithPost = paged.map { it.copy(postUuid = postByPartyUuid[it.partyUuid]?.uuid) }
-        return SentApplicationsSectionResponse(pendingCount = pendingCount, changedCount = changedCount, totalCount = totalCount, applications = pagedWithPost)
+        val itemsWithPost = items.map { it.copy(postUuid = postByPartyUuid[it.partyUuid]?.uuid) }
+        return SentApplicationsSectionResponse(
+            pendingCount = pendingCount.toInt(),
+            changedCount = changedCount.toInt(),
+            totalCount = page.totalElements,
+            applications = itemsWithPost,
+        )
     }
 
     @Transactional

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyRepository.kt
@@ -20,4 +20,16 @@ interface PartyRepository : JpaRepository<Party, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Party p WHERE p.uuid = :uuid")
     fun findByUuidForUpdate(@Param("uuid") uuid: UUID): Party?
+
+    @Query(
+        value = "SELECT p FROM Party p LEFT JOIN FETCH p.plan",
+        countQuery = "SELECT COUNT(p) FROM Party p",
+    )
+    fun findAllWithPlan(pageable: Pageable): Page<Party>
+
+    @Query(
+        value = "SELECT p FROM Party p LEFT JOIN FETCH p.plan WHERE p.plan.uuid = :planUuid",
+        countQuery = "SELECT COUNT(p) FROM Party p WHERE p.plan.uuid = :planUuid",
+    )
+    fun findAllByPlanUuidWithPlan(@Param("planUuid") planUuid: UUID, pageable: Pageable): Page<Party>
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/party/PartyService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/party/PartyService.kt
@@ -128,17 +128,17 @@ class PartyService(
 
     @Transactional(readOnly = true)
     fun getAllParties(pageable: Pageable): Page<GetPartyResponse> {
-        return partyRepository.findAll(pageable).map { GetPartyResponse.of(it) }
+        return partyRepository.findAllWithPlan(pageable).map { GetPartyResponse.of(it) }
     }
 
     @Transactional(readOnly = true)
     fun getPartiesByPlanUuid(planUuid: UUID, pageable: Pageable): Page<GetPartyResponse> {
-        return partyRepository.findAllByPlan_Uuid(planUuid, pageable).map { GetPartyResponse.of(it) }
+        return partyRepository.findAllByPlanUuidWithPlan(planUuid, pageable).map { GetPartyResponse.of(it) }
     }
 
     @Transactional(readOnly = true)
     fun getPartiesByUserUuid(userUuid: UUID, pageable: Pageable): Page<GetPartyResponse> {
-        return userPartyRepository.findAllByUser_Uuid(userUuid, pageable).map { GetPartyResponse.of(it.party) }
+        return userPartyRepository.findAllWithPartyByUserUuid(userUuid, pageable).map { GetPartyResponse.of(it.party) }
     }
 
     @Transactional(readOnly = true)
@@ -600,7 +600,9 @@ class PartyService(
         }
     }
 
-    @Transactional(readOnly = true)
+    // Deliberately NOT @Transactional: the OCI PAR calls below are synchronous network I/O, and
+    // must not run while holding a pooled DB connection (see ADR — Hikari pool exhaustion).
+    // The two repository calls each run in their own short-lived, auto-committed transaction.
     fun resolvePartyThumbnailImageDownloads(partyUuids: List<UUID>): List<ParResponse?> {
         val partyByUuid = partyRepository.findAllByUuidIn(partyUuids).associateBy { it.uuid }
         val postByPartyUuid = postRepository.findAllByParty_UuidIn(partyUuids).associateBy { it.party.uuid }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/Marker.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/Marker.kt
@@ -2,6 +2,7 @@ package com.dogGetDrunk.meetjyou.plan
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -26,7 +27,7 @@ class Marker(
     @Column(length = 500)
     var memo: String? = null,
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     var plan: Plan,
 ) {

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerRepository.kt
@@ -7,5 +7,13 @@ interface MarkerRepository : JpaRepository<Marker, Long> {
     fun findByUuid(uuid: UUID): Marker?
     fun findAllByPlan_UuidOrderByDayNumAscIdxAsc(planUuid: UUID): List<Marker>
     fun findAllByPlan_UuidIn(planUuids: List<UUID>): List<Marker>
+    fun findAllByPlan_UuidInOrderByDayNumAscIdxAsc(planUuids: List<UUID>): List<Marker>
+
+    // NOTE: tried a bulk `@Modifying @Query("DELETE ... WHERE m.plan = :plan")` here to avoid the
+    // row-by-row derived delete, but under concurrent load it caused InnoDB gap-lock deadlocks
+    // against the immediately-following saveAll() insert on the same plan_id range (confirmed via
+    // k6 load test: 19 "Deadlock found when trying to get lock" 500s on PUT .../markers). Reverted
+    // — marker counts per plan are small, so the row-by-row delete's extra statements are cheap
+    // compared to the deadlock risk of a bulk delete sharing a transaction with a same-key insert.
     fun deleteAllByPlan(plan: Plan)
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/MarkerService.kt
@@ -58,7 +58,8 @@ class MarkerService(
         markerRepository.saveAll(newMarkers)
         log.info("Markers replaced for plan=$planUuid count=${newMarkers.size}")
 
-        return markerRepository.findAllByPlan_UuidOrderByDayNumAscIdxAsc(planUuid)
+        return newMarkers
+            .sortedWith(compareBy({ it.dayNum }, { it.idx }))
             .map { MarkerResponse.of(it) }
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/Plan.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/Plan.kt
@@ -3,6 +3,7 @@ package com.dogGetDrunk.meetjyou.plan
 import com.dogGetDrunk.meetjyou.user.User
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -29,7 +30,7 @@ class Plan(
     @Column(length = 500)
     var memo: String? = null,
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "owner_id")
     var owner: User
 ) {

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanService.kt
@@ -85,8 +85,15 @@ class PlanService(
             throw UserNotFoundException(userUuid)
         }
 
-        return planRepository.findAllByOwner_Uuid(userUuid, pageable)
-            .map { GetPlanResponse.of(it, markerRepository.findAllByPlan_UuidOrderByDayNumAscIdxAsc(it.uuid)) }
+        val plans = planRepository.findAllByOwner_Uuid(userUuid, pageable)
+        val markersByPlanUuid = resolveMarkersByPlan(plans.content.map { it.uuid })
+        return plans.map { GetPlanResponse.of(it, markersByPlanUuid[it.uuid] ?: emptyList()) }
+    }
+
+    private fun resolveMarkersByPlan(planUuids: List<UUID>): Map<UUID, List<Marker>> {
+        if (planUuids.isEmpty()) return emptyMap()
+        return markerRepository.findAllByPlan_UuidInOrderByDayNumAscIdxAsc(planUuids)
+            .groupBy { it.plan.uuid }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserController.kt
@@ -176,17 +176,18 @@ class UserController(
             content = arrayOf(
                 Content(
                     mediaType = "application/json",
-                    schema = Schema(
-                        type = "array",
-                        implementation = BasicUserResponse::class
-                    )
+                    schema = Schema(implementation = BasicUserResponse::class)
                 )
             )
         )]
     )
     @Operation(summary = "[admin] 모든 유저 프로필 조회")
-    fun allUsersProfile(): ResponseEntity<List<BasicUserResponse>> {
-        return ResponseEntity.ok(userService.getAllUsersProfile())
+    fun allUsersProfile(
+        @ParameterObject
+        @PageableDefault(size = 20, sort = ["id"])
+        pageable: Pageable,
+    ): ResponseEntity<Page<BasicUserResponse>> {
+        return ResponseEntity.ok(userService.getAllUsersProfile(pageable))
     }
 
     @Operation(summary = "유저 닉네임 중복 확인")

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -18,6 +18,8 @@ import com.dogGetDrunk.meetjyou.user.dto.UserPreferenceData
 import com.dogGetDrunk.meetjyou.user.dto.UserUpdateRequest
 import com.dogGetDrunk.meetjyou.user.dto.normalizeOrNull
 import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -53,10 +55,10 @@ class UserService(
         saveUserPreference(createdUser, request.gender.name, PreferenceType.GENDER)
         saveUserPreference(createdUser, request.age.name, PreferenceType.AGE)
 
-        request.personalities.forEach { saveUserPreference(createdUser, it.name, PreferenceType.PERSONALITY) }
-        request.travelStyles.forEach { saveUserPreference(createdUser, it.name, PreferenceType.TRAVEL_STYLE) }
-        request.diet.forEach { saveUserPreference(createdUser, it.name, PreferenceType.DIET) }
-        request.etc.forEach { saveUserPreference(createdUser, it.name, PreferenceType.ETC) }
+        saveUserPreferences(createdUser, request.personalities.map { it.name }, PreferenceType.PERSONALITY)
+        saveUserPreferences(createdUser, request.travelStyles.map { it.name }, PreferenceType.TRAVEL_STYLE)
+        saveUserPreferences(createdUser, request.diet.map { it.name }, PreferenceType.DIET)
+        saveUserPreferences(createdUser, request.etc.map { it.name }, PreferenceType.ETC)
 
         log.info("User saved successfully. uuid: {}, email: {}", createdUser.uuid, createdUser.email)
 
@@ -105,10 +107,10 @@ class UserService(
     }
 
     @Transactional(readOnly = true)
-    fun getAllUsersProfile(): List<BasicUserResponse> {
-        val users = userRepository.findAll()
-        if (users.isEmpty()) return emptyList()
-        val prefsMap = userPreferenceRepository.findAllByUser_IdIn(users.map { it.id })
+    fun getAllUsersProfile(pageable: Pageable): Page<BasicUserResponse> {
+        val users = userRepository.findAll(pageable)
+        if (users.isEmpty) return users.map { BasicUserResponse.of(it, emptyList()) }
+        val prefsMap = userPreferenceRepository.findAllByUser_IdIn(users.content.map { it.id })
             .groupBy { it.user.id }
         return users.map { BasicUserResponse.of(it, prefsMap[it.id] ?: emptyList()) }
     }
@@ -142,13 +144,20 @@ class UserService(
         } ?: log.warn(PREFERENCE_NOT_FOUND, preferenceName, type)
     }
 
+    fun saveUserPreferences(user: User, preferenceNames: List<String>, type: PreferenceType) {
+        if (preferenceNames.isEmpty()) return
+        val preferenceByName = preferenceRepository.findAllByTypeAndNameIn(type, preferenceNames)
+            .associateBy { it.name }
+        val userPreferences = preferenceNames.mapNotNull { name ->
+            preferenceByName[name]?.let { UserPreference(user, it) }
+                ?: run { log.warn(PREFERENCE_NOT_FOUND, name, type); null }
+        }
+        userPreferenceRepository.saveAll(userPreferences)
+    }
+
     fun updateUserPreferences(user: User, preferenceNames: List<String>, type: PreferenceType) {
         userPreferenceRepository.deleteByUserIdAndType(user.id, type)
-        preferenceNames.forEach { preferenceName ->
-            preferenceRepository.findByNameAndType(preferenceName, type)?.let { preference ->
-                userPreferenceRepository.save(UserPreference(user, preference))
-            } ?: log.warn(PREFERENCE_NOT_FOUND, preferenceName, type)
-        }
+        saveUserPreferences(user, preferenceNames, type)
     }
 
     fun updateUserPreference(user: User, preferenceName: String?, type: PreferenceType) {
@@ -160,21 +169,22 @@ class UserService(
         }
     }
 
-    fun getPreferenceName(userId: Long, type: PreferenceType): String {
-        return userPreferenceRepository.findPreferenceByUserIdAndType(userId, type)?.name
+    // Single batch query instead of one findPreference(Name)?ByUserIdAndType call per preference type.
+    private fun loadPreferences(userId: Long): UserPreferenceData {
+        val userPrefs = userPreferenceRepository.findAllByUser_IdIn(listOf(userId))
+        fun name(type: PreferenceType) = userPrefs
+            .firstOrNull { it.preference.type == type }?.preference?.name
             ?: throw PreferenceNotFoundException(type.name)
-    }
+        fun nameList(type: PreferenceType) = userPrefs
+            .filter { it.preference.type == type }.map { it.preference.name }
 
-    private fun getPreferenceNames(userId: Long, type: PreferenceType): List<String> {
-        return userPreferenceRepository.findPreferencesByUserIdAndType(userId, type).map { it.name }
+        return UserPreferenceData(
+            gender = name(PreferenceType.GENDER),
+            age = name(PreferenceType.AGE),
+            personalities = nameList(PreferenceType.PERSONALITY),
+            travelStyles = nameList(PreferenceType.TRAVEL_STYLE),
+            diet = nameList(PreferenceType.DIET),
+            etc = nameList(PreferenceType.ETC),
+        )
     }
-
-    private fun loadPreferences(userId: Long): UserPreferenceData = UserPreferenceData(
-        gender = getPreferenceName(userId, PreferenceType.GENDER),
-        age = getPreferenceName(userId, PreferenceType.AGE),
-        personalities = getPreferenceNames(userId, PreferenceType.PERSONALITY),
-        travelStyles = getPreferenceNames(userId, PreferenceType.TRAVEL_STYLE),
-        diet = getPreferenceNames(userId, PreferenceType.DIET),
-        etc = getPreferenceNames(userId, PreferenceType.ETC),
-    )
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/userparty/UserPartyRepository.kt
@@ -30,9 +30,33 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
         userUuid: UUID,
     ): List<UserParty>
 
+    fun findAllByParty_UuidAndUser_UuidIn(
+        partyUuid: UUID,
+        userUuids: Collection<UUID>,
+    ): List<UserParty>
+
     fun findAllByUser_Uuid(
         userUuid: UUID,
         pageable: Pageable
+    ): Page<UserParty>
+
+    @Query(
+        value = """
+            select up
+            from UserParty up
+            join fetch up.party p
+            left join fetch p.plan
+            where up.user.uuid = :userUuid
+        """,
+        countQuery = """
+            select count(up)
+            from UserParty up
+            where up.user.uuid = :userUuid
+        """
+    )
+    fun findAllWithPartyByUserUuid(
+        @Param("userUuid") userUuid: UUID,
+        pageable: Pageable,
     ): Page<UserParty>
 
     fun findAllByParty_Uuid(partyUuid: UUID): List<UserParty>
@@ -116,6 +140,40 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
     """)
     fun findAllPendingRequestsForHost(@Param("hostUuid") hostUuid: UUID): List<UserParty>
 
+    @Query(
+        value = """
+            select up from UserParty up
+            join fetch up.user
+            join fetch up.party
+            where up.party in (
+                select h.party from UserParty h
+                where h.user.uuid = :hostUuid and h.role = 'HOST' and h.memberStatus = 'JOINED'
+            )
+            and up.memberStatus = 'PENDING'
+            order by up.joinedAt desc
+        """,
+        countQuery = """
+            select count(up) from UserParty up
+            where up.party in (
+                select h.party from UserParty h
+                where h.user.uuid = :hostUuid and h.role = 'HOST' and h.memberStatus = 'JOINED'
+            )
+            and up.memberStatus = 'PENDING'
+        """
+    )
+    fun findAllPendingRequestsForHost(@Param("hostUuid") hostUuid: UUID, pageable: Pageable): Page<UserParty>
+
+    @Query("""
+        select count(up) from UserParty up
+        where up.party in (
+            select h.party from UserParty h
+            where h.user.uuid = :hostUuid and h.role = 'HOST' and h.memberStatus = 'JOINED'
+        )
+        and up.memberStatus = 'PENDING'
+        and up.hostRead = false
+    """)
+    fun countUnreadPendingRequestsForHost(@Param("hostUuid") hostUuid: UUID): Long
+
     @Query("""
         select up from UserParty up
         join fetch up.party
@@ -125,6 +183,23 @@ interface UserPartyRepository : JpaRepository<UserParty, Long> {
         order by up.statusChangedAt desc
     """)
     fun findAllSentApplicationsByUserUuid(@Param("userUuid") userUuid: UUID): List<UserParty>
+
+    @Query("""
+        select count(up) from UserParty up
+        where up.user.uuid = :userUuid
+        and up.role = 'MEMBER'
+        and up.memberStatus = 'PENDING'
+    """)
+    fun countPendingSentApplications(@Param("userUuid") userUuid: UUID): Long
+
+    @Query("""
+        select count(up) from UserParty up
+        where up.user.uuid = :userUuid
+        and up.role = 'MEMBER'
+        and up.memberStatus in ('JOINED', 'REJECTED')
+        and up.applicantRead = false
+    """)
+    fun countChangedUnreadSentApplications(@Param("userUuid") userUuid: UUID): Long
 
     @Query(
         value = """

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,8 +24,9 @@ spring:
       keepalive-time: 240000      # 4분마다 idle connection ping
       idle-timeout: 600000
       max-lifetime: 1800000
-      maximum-pool-size: 5        # 프리티어 환경에 맞게 축소
+      maximum-pool-size: 5        # 프리티어 환경에 맞게 축소 (30으로 늘리면 풀 고갈 해소 확인됨 - OCI 실제 max_connections 확인 후 재검토)
       minimum-idle: 2
+      connection-timeout: 5000    # 풀 고갈 시 30초 대기 대신 5초 내 빠른 실패
       connection-test-query: SELECT 1
   servlet:
     multipart:

--- a/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatReadServiceQueryOptimizationTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatReadServiceQueryOptimizationTest.kt
@@ -1,0 +1,89 @@
+package com.dogGetDrunk.meetjyou.chat
+
+import com.dogGetDrunk.meetjyou.chat.event.ChatRoomEventBroadcaster
+import com.dogGetDrunk.meetjyou.chat.message.ChatMessageRepository
+import com.dogGetDrunk.meetjyou.chat.room.ChatRoom
+import com.dogGetDrunk.meetjyou.chat.room.ChatRoomRepository
+import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
+import com.dogGetDrunk.meetjyou.notificationcenter.support.NotificationCenterFixtures
+import com.dogGetDrunk.meetjyou.user.support.UserFixtures
+import com.dogGetDrunk.meetjyou.userparty.MemberStatus
+import com.dogGetDrunk.meetjyou.userparty.PartyRole
+import com.dogGetDrunk.meetjyou.userparty.UserParty
+import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+
+// Regression tests for the chat-module query-duplication fixes:
+// - getChatRooms must fetch the caller's memberships once and reuse them for unread counting,
+//   not re-query the identical membership list inside buildUnreadCountMap.
+// - markLatestMessageAsReadForUsers must resolve the room's partyUuid once and batch-load all
+//   target users' memberships in one query, not once per user in the loop.
+class ChatReadServiceQueryOptimizationTest : BehaviorSpec() {
+
+    private val chatMessageRepository = mockk<ChatMessageRepository>(relaxed = true)
+    private val chatRoomRepository = mockk<ChatRoomRepository>(relaxed = true)
+    private val userPartyRepository = mockk<UserPartyRepository>(relaxed = true)
+    private val chatRoomEventBroadcaster = mockk<ChatRoomEventBroadcaster>(relaxed = true)
+    private val currentUserProvider = mockk<CurrentUserProvider>(relaxed = true)
+
+    private val sut = ChatReadService(
+        chatMessageRepository, chatRoomRepository, userPartyRepository, chatRoomEventBroadcaster, currentUserProvider,
+    )
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        given("getChatRooms 호출 시") {
+            `when`("본인이 가입한 파티가 있으면") {
+                then("본인 멤버십을 한 번만 조회하고 unread count 계산에 그대로 재사용한다") {
+                    val requester = UserFixtures.user()
+                    val party = NotificationCenterFixtures.party()
+                    val membership = NotificationCenterFixtures.hostUserParty(party, requester)
+                    val room = ChatRoom(party = party)
+
+                    every { currentUserProvider.uuid } returns requester.uuid
+                    every {
+                        userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(requester.uuid, MemberStatus.JOINED)
+                    } returns listOf(membership)
+                    every { chatRoomRepository.findAllWithPartyByPartyUuidIn(setOf(party.uuid)) } returns listOf(room)
+
+                    sut.getChatRooms()
+
+                    verify(exactly = 1) {
+                        userPartyRepository.findAllWithPartyByUserUuidAndMemberStatus(requester.uuid, MemberStatus.JOINED)
+                    }
+                }
+            }
+        }
+
+        given("markLatestMessageAsReadForUsers 호출 시") {
+            `when`("여러 유저의 읽음 위치를 갱신하면") {
+                then("유저별 개별 조회 대신 파티 조회 1회 + 멤버십 배치 조회 1회만 수행한다") {
+                    val party = NotificationCenterFixtures.party()
+                    val roomUuid = UUID.randomUUID()
+                    val userA = UserFixtures.user(email = "a@example.com", nickname = "a")
+                    val userB = UserFixtures.user(email = "b@example.com", nickname = "b")
+                    val membershipA = UserParty(party, userA, PartyRole.MEMBER)
+                    val membershipB = UserParty(party, userB, PartyRole.MEMBER)
+                    val targetUuids = setOf(userA.uuid, userB.uuid)
+
+                    every { chatRoomRepository.findPartyUuidByRoomUuid(roomUuid) } returns party.uuid
+                    every {
+                        userPartyRepository.findAllByParty_UuidAndUser_UuidIn(party.uuid, targetUuids)
+                    } returns listOf(membershipA, membershipB)
+
+                    sut.markLatestMessageAsReadForUsers(roomUuid, targetUuids, 42L)
+
+                    verify(exactly = 1) { chatRoomRepository.findPartyUuidByRoomUuid(roomUuid) }
+                    verify(exactly = 1) { userPartyRepository.findAllByParty_UuidAndUser_UuidIn(party.uuid, targetUuids) }
+                    verify(exactly = 0) { userPartyRepository.findByParty_UuidAndUser_Uuid(any(), any()) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notification/dispatcher/NotificationDispatcherTest.kt
@@ -37,11 +37,12 @@ class NotificationDispatcherTest : BehaviorSpec() {
 
         given("dispatchBatch 호출 시") {
 
-            `when`("processItem이 예외를 던지면") {
+            `when`("토큰 조회는 성공했지만 FCM 전송이 예외를 던지면") {
                 then("해당 item이 PENDING으로 재전환된다") {
                     val item = outbox()
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
-                    every { targetResolver.resolveUserTargets(any()) } throws RuntimeException("FCM error")
+                    every { targetResolver.resolveUserTargets(any()) } returns mapOf(item.user.id to listOf("token-abc"))
+                    every { sender.send(any(), any(), any(), any()) } throws RuntimeException("FCM error")
 
                     sut.dispatchBatch(1)
 
@@ -54,13 +55,14 @@ class NotificationDispatcherTest : BehaviorSpec() {
                 }
             }
 
-            `when`("첫 번째 item이 예외를 던지고 두 번째 item은 정상이면") {
+            `when`("첫 번째 item 전송은 예외를 던지고 두 번째 item은 정상이면") {
                 then("첫 번째는 PENDING, 두 번째는 SENT로 처리된다") {
                     val failItem = outbox()
                     val okItem = outbox()
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(failItem, okItem)
-                    every { targetResolver.resolveUserTargets(any()) } throws RuntimeException("FCM error") andThen listOf("token-abc")
-                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = true)
+                    every { targetResolver.resolveUserTargets(any()) } returns
+                        mapOf(failItem.user.id to listOf("token-abc"), okItem.user.id to listOf("token-abc"))
+                    every { sender.send(any(), any(), any(), any()) } throws RuntimeException("FCM error") andThen SendResult(ok = true)
 
                     sut.dispatchBatch(2)
 
@@ -74,12 +76,13 @@ class NotificationDispatcherTest : BehaviorSpec() {
             }
 
             `when`("item이 없으면") {
-                then("아무 처리도 하지 않는다") {
+                then("아무 처리도 하지 않고 토큰도 조회하지 않는다") {
                     every { outboxRepository.lockNextPendings(any()) } returns emptyList()
 
                     sut.dispatchBatch(10)
 
                     verify(exactly = 0) { outboxRepository.updateResult(any(), any(), any(), any()) }
+                    verify(exactly = 0) { targetResolver.resolveUserTargets(any()) }
                 }
             }
 
@@ -87,7 +90,7 @@ class NotificationDispatcherTest : BehaviorSpec() {
                 then("SENT로 처리된다") {
                     val item = outbox()
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
-                    every { targetResolver.resolveUserTargets(any()) } returns emptyList()
+                    every { targetResolver.resolveUserTargets(any()) } returns emptyMap()
 
                     sut.dispatchBatch(1)
 
@@ -101,7 +104,7 @@ class NotificationDispatcherTest : BehaviorSpec() {
                 then("SENT로 처리된다") {
                     val item = outbox()
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
-                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { targetResolver.resolveUserTargets(any()) } returns mapOf(item.user.id to listOf("token-abc"))
                     every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = true)
 
                     sut.dispatchBatch(1)
@@ -116,7 +119,7 @@ class NotificationDispatcherTest : BehaviorSpec() {
                 then("DEAD로 처리된다") {
                     val item = outbox()
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
-                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { targetResolver.resolveUserTargets(any()) } returns mapOf(item.user.id to listOf("token-abc"))
                     every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = false, permanent = true)
 
                     sut.dispatchBatch(1)
@@ -131,7 +134,7 @@ class NotificationDispatcherTest : BehaviorSpec() {
                 then("DEAD로 처리된다") {
                     val item = outbox(attempts = 4) // nextAttempts=5 >= backoffSeconds.size=5
                     every { outboxRepository.lockNextPendings(any()) } returns listOf(item)
-                    every { targetResolver.resolveUserTargets(any()) } returns listOf("token-abc")
+                    every { targetResolver.resolveUserTargets(any()) } returns mapOf(item.user.id to listOf("token-abc"))
                     every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = false)
 
                     sut.dispatchBatch(1)
@@ -139,6 +142,20 @@ class NotificationDispatcherTest : BehaviorSpec() {
                     verify(exactly = 1) {
                         outboxRepository.updateResult(item.id, DeliveryStatus.DEAD, any(), any())
                     }
+                }
+            }
+
+            `when`("여러 item이 같은 유저 것이면") {
+                then("유저별 토큰 조회를 건별이 아닌 배치로 한 번만 수행한다") {
+                    val item1 = outbox()
+                    val item2 = outbox()
+                    every { outboxRepository.lockNextPendings(any()) } returns listOf(item1, item2)
+                    every { targetResolver.resolveUserTargets(any()) } returns mapOf(item1.user.id to listOf("token-abc"))
+                    every { sender.send(any(), any(), any(), any()) } returns SendResult(ok = true)
+
+                    sut.dispatchBatch(2)
+
+                    verify(exactly = 1) { targetResolver.resolveUserTargets(any()) }
                 }
             }
         }

--- a/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/notificationcenter/NotificationCenterServiceTest.kt
@@ -100,12 +100,14 @@ class NotificationCenterServiceTest : BehaviorSpec() {
             beforeEach { every { currentUserProvider.uuid } returns hostUuid }
 
             `when`("PENDING 신청이 있고 hostRead=false인 경우") {
-                then("unreadCount가 올바르게 집계된다") {
+                then("unreadCount가 올바르게 집계되고, 목록은 페이지네이션 쿼리 결과를 그대로 사용한다") {
+                    val pageable = Pageable.ofSize(20)
                     val pending = NotificationCenterFixtures.pendingUserParty(party, applicant, "Hello!")
-                    every { userPartyRepository.findAllPendingRequestsForHost(hostUuid) } returns listOf(pending)
+                    every { userPartyRepository.countUnreadPendingRequestsForHost(hostUuid) } returns 1
+                    every { userPartyRepository.findAllPendingRequestsForHost(hostUuid, pageable) } returns PageImpl(listOf(pending))
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getReceivedApplications(Pageable.ofSize(20))
+                    val result = sut.getReceivedApplications(pageable)
 
                     result.unreadCount shouldBe 1
                     result.applications.size shouldBe 1
@@ -117,10 +119,12 @@ class NotificationCenterServiceTest : BehaviorSpec() {
 
             `when`("신청이 없는 경우") {
                 then("빈 목록과 unreadCount=0을 반환한다") {
-                    every { userPartyRepository.findAllPendingRequestsForHost(hostUuid) } returns emptyList()
+                    val pageable = Pageable.ofSize(20)
+                    every { userPartyRepository.countUnreadPendingRequestsForHost(hostUuid) } returns 0
+                    every { userPartyRepository.findAllPendingRequestsForHost(hostUuid, pageable) } returns PageImpl(emptyList())
                     every { postRepository.findAllByParty_UuidIn(emptyList()) } returns emptyList()
 
-                    val result = sut.getReceivedApplications(Pageable.ofSize(20))
+                    val result = sut.getReceivedApplications(pageable)
 
                     result.unreadCount shouldBe 0
                     result.applications shouldBe emptyList()
@@ -161,11 +165,14 @@ class NotificationCenterServiceTest : BehaviorSpec() {
 
             `when`("PENDING 신청이 있는 경우") {
                 then("pendingCount=1, status=PENDING, read=true로 반환된다") {
+                    val pageable = Pageable.ofSize(20)
                     val pending = NotificationCenterFixtures.pendingUserParty(party, user)
-                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(pending)
+                    every { userPartyRepository.countPendingSentApplications(userUuid) } returns 1
+                    every { userPartyRepository.countChangedUnreadSentApplications(userUuid) } returns 0
+                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid, pageable) } returns PageImpl(listOf(pending))
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(Pageable.ofSize(20))
+                    val result = sut.getSentApplications(pageable)
 
                     result.pendingCount shouldBe 1
                     result.changedCount shouldBe 0
@@ -176,12 +183,15 @@ class NotificationCenterServiceTest : BehaviorSpec() {
 
             `when`("ACCEPTED 신청(applicantRead=false)이 있는 경우") {
                 then("changedCount=1, status=ACCEPTED, read=false로 반환된다") {
+                    val pageable = Pageable.ofSize(20)
                     val accepted = NotificationCenterFixtures.pendingUserParty(party, user)
                     accepted.approve()
-                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(accepted)
+                    every { userPartyRepository.countPendingSentApplications(userUuid) } returns 0
+                    every { userPartyRepository.countChangedUnreadSentApplications(userUuid) } returns 1
+                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid, pageable) } returns PageImpl(listOf(accepted))
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(Pageable.ofSize(20))
+                    val result = sut.getSentApplications(pageable)
 
                     result.changedCount shouldBe 1
                     result.applications[0].status shouldBe ApplicationStatus.ACCEPTED
@@ -191,12 +201,15 @@ class NotificationCenterServiceTest : BehaviorSpec() {
 
             `when`("REJECTED 신청(applicantRead=false)이 있는 경우") {
                 then("changedCount=1, status=REJECTED, read=false로 반환된다") {
+                    val pageable = Pageable.ofSize(20)
                     val rejected = NotificationCenterFixtures.pendingUserParty(party, user)
                     rejected.reject()
-                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid) } returns listOf(rejected)
+                    every { userPartyRepository.countPendingSentApplications(userUuid) } returns 0
+                    every { userPartyRepository.countChangedUnreadSentApplications(userUuid) } returns 1
+                    every { userPartyRepository.findAllSentApplicationsByUserUuid(userUuid, pageable) } returns PageImpl(listOf(rejected))
                     every { postRepository.findAllByParty_UuidIn(listOf(party.uuid)) } returns listOf(post)
 
-                    val result = sut.getSentApplications(Pageable.ofSize(20))
+                    val result = sut.getSentApplications(pageable)
 
                     result.changedCount shouldBe 1
                     result.applications[0].status shouldBe ApplicationStatus.REJECTED

--- a/src/test/java/com/dogGetDrunk/meetjyou/party/PartyQueryOptimizationTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/party/PartyQueryOptimizationTest.kt
@@ -1,0 +1,117 @@
+package com.dogGetDrunk.meetjyou.party
+
+import com.dogGetDrunk.meetjyou.chat.event.ChatRoomEventBroadcaster
+import com.dogGetDrunk.meetjyou.chat.participant.ChatParticipantService
+import com.dogGetDrunk.meetjyou.chat.room.ChatRoomRepository
+import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
+import com.dogGetDrunk.meetjyou.image.cloud.oracle.service.PartyImgService
+import com.dogGetDrunk.meetjyou.image.cloud.oracle.service.PostImgService
+import com.dogGetDrunk.meetjyou.notificationcenter.support.NotificationCenterFixtures
+import com.dogGetDrunk.meetjyou.plan.MarkerRepository
+import com.dogGetDrunk.meetjyou.plan.PlanRepository
+import com.dogGetDrunk.meetjyou.post.PostRepository
+import com.dogGetDrunk.meetjyou.user.UserRepository
+import com.dogGetDrunk.meetjyou.user.support.UserFixtures
+import com.dogGetDrunk.meetjyou.userparty.PartyRole
+import com.dogGetDrunk.meetjyou.userparty.UserParty
+import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.every
+import io.mockk.verify
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.functions
+
+// Regression tests for the party-module N+1 fixes: getAllParties / getPartiesByPlanUuid /
+// getPartiesByUserUuid must go through the join-fetch repository methods, not the plain
+// findAll/findAllByUser_Uuid ones that force a lazy load of party.plan per row.
+class PartyQueryOptimizationTest : BehaviorSpec() {
+
+    private val partyRepository = mockk<PartyRepository>(relaxed = true)
+    private val postRepository = mockk<PostRepository>(relaxed = true)
+    private val planRepository = mockk<PlanRepository>(relaxed = true)
+    private val markerRepository = mockk<MarkerRepository>(relaxed = true)
+    private val chatRoomRepository = mockk<ChatRoomRepository>(relaxed = true)
+    private val chatParticipantService = mockk<ChatParticipantService>(relaxed = true)
+    private val chatRoomEventBroadcaster = mockk<ChatRoomEventBroadcaster>(relaxed = true)
+    private val userPartyRepository = mockk<UserPartyRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val publisher = mockk<ApplicationEventPublisher>(relaxed = true)
+    private val partyImgService = mockk<PartyImgService>(relaxed = true)
+    private val postImgService = mockk<PostImgService>(relaxed = true)
+    private val objectMapper = ObjectMapper()
+    private val currentUserProvider = mockk<CurrentUserProvider>(relaxed = true)
+
+    private val sut = PartyService(
+        partyRepository, postRepository, planRepository, markerRepository, chatRoomRepository,
+        chatParticipantService, chatRoomEventBroadcaster, userPartyRepository, userRepository,
+        publisher, partyImgService, postImgService, objectMapper, currentUserProvider,
+    )
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    init {
+        val user = UserFixtures.user()
+        val party = NotificationCenterFixtures.party()
+        val pageable = PageRequest.of(0, 10)
+
+        given("전체 파티 목록 조회 시") {
+            `when`("getAllParties를 호출하면") {
+                then("plan을 LEFT JOIN FETCH하는 findAllWithPlan을 사용하고 findAll은 호출하지 않는다") {
+                    every { partyRepository.findAllWithPlan(pageable) } returns PageImpl(listOf(party))
+
+                    sut.getAllParties(pageable)
+
+                    verify(exactly = 1) { partyRepository.findAllWithPlan(pageable) }
+                    verify(exactly = 0) { partyRepository.findAll(pageable) }
+                }
+            }
+        }
+
+        given("plan 기준 파티 목록 조회 시") {
+            `when`("getPartiesByPlanUuid를 호출하면") {
+                then("plan을 LEFT JOIN FETCH하는 findAllByPlanUuidWithPlan을 사용한다") {
+                    val planUuid = UUID.randomUUID()
+                    every { partyRepository.findAllByPlanUuidWithPlan(planUuid, pageable) } returns PageImpl(listOf(party))
+
+                    sut.getPartiesByPlanUuid(planUuid, pageable)
+
+                    verify(exactly = 1) { partyRepository.findAllByPlanUuidWithPlan(planUuid, pageable) }
+                    verify(exactly = 0) { partyRepository.findAllByPlan_Uuid(planUuid, pageable) }
+                }
+            }
+        }
+
+        given("유저 기준 파티 목록 조회 시") {
+            `when`("getPartiesByUserUuid를 호출하면") {
+                then("party를 JOIN FETCH하는 findAllWithPartyByUserUuid를 사용하고 findAllByUser_Uuid는 호출하지 않는다") {
+                    val userParty = UserParty(party, user, PartyRole.MEMBER)
+                    every { userPartyRepository.findAllWithPartyByUserUuid(user.uuid, pageable) } returns PageImpl(listOf(userParty))
+
+                    val result = sut.getPartiesByUserUuid(user.uuid, pageable)
+
+                    result.content.single().uuid shouldBe party.uuid
+                    verify(exactly = 1) { userPartyRepository.findAllWithPartyByUserUuid(user.uuid, pageable) }
+                    verify(exactly = 0) { userPartyRepository.findAllByUser_Uuid(user.uuid, pageable) }
+                }
+            }
+        }
+
+        given("파티 썸네일 다운로드 PAR 생성 시") {
+            `when`("resolvePartyThumbnailImageDownloads의 트랜잭션 경계를 확인하면") {
+                then("OCI 호출을 커넥션 풀 점유 없이 수행하도록 @Transactional이 없다") {
+                    val method = PartyService::class.functions.single { it.name == "resolvePartyThumbnailImageDownloads" }
+                    method.findAnnotation<Transactional>() shouldBe null
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/dogGetDrunk/meetjyou/plan/MarkerServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/plan/MarkerServiceTest.kt
@@ -105,17 +105,15 @@ class MarkerServiceTest : BehaviorSpec() {
             )
 
             `when`("plan이 존재하고 본인 소유이면") {
-                then("기존 마커를 삭제하고 새 마커를 저장한 뒤 목록을 반환한다") {
-                    val savedMarker = PlanFixtures.marker(plan, dayNum = 1, idx = 0)
-
+                then("기존 마커를 삭제하고 새 마커를 저장한 뒤, 재조회 없이 저장한 목록을 그대로 반환한다") {
                     every { planRepository.findByUuid(plan.uuid) } returns plan
                     every { currentUserProvider.uuid } returns owner.uuid
-                    every { markerRepository.findAllByPlan_UuidOrderByDayNumAscIdxAsc(plan.uuid) } returns listOf(savedMarker)
 
                     val result = sut.replaceMarkers(plan.uuid, markerRequests)
 
                     verify(exactly = 1) { markerRepository.deleteAllByPlan(plan) }
                     verify(exactly = 1) { markerRepository.saveAll(any<List<Marker>>()) }
+                    verify(exactly = 0) { markerRepository.findAllByPlan_UuidOrderByDayNumAscIdxAsc(any()) }
                     result.size shouldBe 1
                 }
             }

--- a/src/test/java/com/dogGetDrunk/meetjyou/plan/PlanServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/plan/PlanServiceTest.kt
@@ -111,6 +111,44 @@ class PlanServiceTest : BehaviorSpec() {
             }
         }
 
+        // ── getPlansByUserUuid ───────────────────────────────────────────────
+
+        given("getPlansByUserUuid 호출 시") {
+            `when`("유저가 여러 계획서를 소유하고 있으면") {
+                then("marker를 계획서 개수만큼 반복 조회하지 않고 배치로 한 번에 조회한다") {
+                    val owner = UserFixtures.user()
+                    val planA = PlanFixtures.plan(owner)
+                    val planB = PlanFixtures.plan(owner)
+                    val page = PageImpl(listOf(planA, planB))
+                    val markerOnA = PlanFixtures.marker(planA)
+
+                    every { userRepository.existsByUuid(owner.uuid) } returns true
+                    every { planRepository.findAllByOwner_Uuid(owner.uuid, any()) } returns page
+                    every {
+                        markerRepository.findAllByPlan_UuidInOrderByDayNumAscIdxAsc(listOf(planA.uuid, planB.uuid))
+                    } returns listOf(markerOnA)
+
+                    val result = sut.getPlansByUserUuid(owner.uuid, Pageable.unpaged())
+
+                    result.content.first { it.uuid == planA.uuid }.markers.size shouldBe 1
+                    result.content.first { it.uuid == planB.uuid }.markers.size shouldBe 0
+                    verify(exactly = 1) { markerRepository.findAllByPlan_UuidInOrderByDayNumAscIdxAsc(any()) }
+                    verify(exactly = 0) { markerRepository.findAllByPlan_UuidOrderByDayNumAscIdxAsc(any()) }
+                }
+            }
+
+            `when`("유저가 존재하지 않으면") {
+                then("UserNotFoundException을 던진다") {
+                    val unknownUuid = UUID.randomUUID()
+                    every { userRepository.existsByUuid(unknownUuid) } returns false
+
+                    shouldThrow<UserNotFoundException> {
+                        sut.getPlansByUserUuid(unknownUuid, Pageable.unpaged())
+                    }
+                }
+            }
+        }
+
         // ── getPlanByUuid ────────────────────────────────────────────────────
 
         given("getPlanByUuid 호출 시") {

--- a/src/test/java/com/dogGetDrunk/meetjyou/user/UserServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/user/UserServiceTest.kt
@@ -3,7 +3,10 @@ package com.dogGetDrunk.meetjyou.user
 import com.dogGetDrunk.meetjyou.auth.refreshtoken.RefreshTokenRepository
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
 import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
+import com.dogGetDrunk.meetjyou.preference.Preference
 import com.dogGetDrunk.meetjyou.preference.PreferenceRepository
+import com.dogGetDrunk.meetjyou.preference.PreferenceType
+import com.dogGetDrunk.meetjyou.preference.UserPreference
 import com.dogGetDrunk.meetjyou.preference.UserPreferenceRepository
 import com.dogGetDrunk.meetjyou.terms.TermsService
 import com.dogGetDrunk.meetjyou.terms.TermsType
@@ -17,6 +20,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.mockk.verify
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 
 class UserServiceTest : BehaviorSpec() {
     private val userRepository = mockk<UserRepository>(relaxed = true)
@@ -139,14 +144,17 @@ class UserServiceTest : BehaviorSpec() {
         // ── getUserProfile (hasProfileImage pass-through) ─────────────────────
 
         given("getUserProfile 호출 시") {
+            fun requiredPreferences(user: User): List<UserPreference> = listOf(
+                UserPreference(user, Preference(type = PreferenceType.GENDER, name = "SOME_VALUE")),
+                UserPreference(user, Preference(type = PreferenceType.AGE, name = "SOME_VALUE")),
+            )
+
             `when`("유저에 hasProfileImage가 false인 경우") {
                 then("응답의 hasProfileImage도 false이다") {
                     val user = UserFixtures.user()
 
                     every { userRepository.findByUuid(user.uuid) } returns user
-                    every { userPreferenceRepository.findPreferenceByUserIdAndType(any(), any()) } returns
-                            mockk { every { name } returns "SOME_VALUE" }
-                    every { userPreferenceRepository.findPreferencesByUserIdAndType(any(), any()) } returns emptyList()
+                    every { userPreferenceRepository.findAllByUser_IdIn(listOf(user.id)) } returns requiredPreferences(user)
 
                     val result = sut.getUserProfile(user.uuid)
 
@@ -161,13 +169,36 @@ class UserServiceTest : BehaviorSpec() {
                     }
 
                     every { userRepository.findByUuid(user.uuid) } returns user
-                    every { userPreferenceRepository.findPreferenceByUserIdAndType(any(), any()) } returns
-                            mockk { every { name } returns "SOME_VALUE" }
-                    every { userPreferenceRepository.findPreferencesByUserIdAndType(any(), any()) } returns emptyList()
+                    every { userPreferenceRepository.findAllByUser_IdIn(listOf(user.id)) } returns requiredPreferences(user)
 
                     val result = sut.getUserProfile(user.uuid)
 
                     result.hasProfileImage shouldBe true
+                }
+            }
+        }
+
+        // ── getAllUsersProfile ───────────────────────────────────────────────
+
+        given("getAllUsersProfile 호출 시") {
+            `when`("페이지 요청이 들어오면") {
+                then("userRepository.findAll(pageable)로 페이지네이션되고, preference는 유저 수와 무관하게 배치로 한 번만 조회한다") {
+                    val user = UserFixtures.user()
+                    val pageable = PageRequest.of(0, 20)
+                    val page = PageImpl(listOf(user))
+                    val prefs = listOf(
+                        UserPreference(user, Preference(type = PreferenceType.GENDER, name = "SOME_VALUE")),
+                        UserPreference(user, Preference(type = PreferenceType.AGE, name = "SOME_VALUE")),
+                    )
+
+                    every { userRepository.findAll(pageable) } returns page
+                    every { userPreferenceRepository.findAllByUser_IdIn(listOf(user.id)) } returns prefs
+
+                    val result = sut.getAllUsersProfile(pageable)
+
+                    result.content.single().uuid shouldBe user.uuid
+                    verify(exactly = 1) { userRepository.findAll(pageable) }
+                    verify(exactly = 1) { userPreferenceRepository.findAllByUser_IdIn(listOf(user.id)) }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Hikari `connection-timeout`을 기본값 30초에서 5초로 단축 — 커넥션 풀 고갈 시 fail-fast
- party/plan/chat/user/notification/image 6개 모듈의 N+1·중복 쿼리 수정 (자세한 내용은 커밋 메시지 참고)
- `MarkerRepository.deleteAllByPlan` 벌크 삭제 시도 → 부하테스트에서 InnoDB 데드락 재현되어 row-by-row로 원복
- 로컬/운영 전체 API 커버 k6 부하테스트 스크립트 추가 (`full-api-scenario.js`, `prod-full-read-scenario.js`)

## Test plan
- [x] `./gradlew test` 전체 229개 통과
- [x] 로컬 k6 50VU 부하테스트로 before/after 검증 (http_req_duration max 30.38s → 5.06s, 처리량 194→231 req/s)
- [x] Hikari 풀 사이즈 5→30 임시 테스트로 풀 고갈 완전 해소 확인 (운영 반영은 OCI 실제 max_connections 확인 후 별도 진행)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>