### PR TITLE
fix: XFF 신뢰 경계 검증 및 강화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
     depends_on:
       - spring_boot
     networks:
-      - my_network
+      my_network:
+        ipv4_address: 172.28.0.10
 
   certbot:
     container_name: certbot
@@ -51,3 +52,6 @@ services:
 networks:
   my_network:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/24

--- a/src/main/resources/application-release.yml
+++ b/src/main/resources/application-release.yml
@@ -1,3 +1,10 @@
 logging:
   level:
     org.springframework.security: INFO
+
+server:
+  tomcat:
+    remoteip:
+      # Only trust X-Forwarded-For/-Proto from the nginx container's static IP
+      # (see docker-compose.yml my_network) instead of Tomcat's default RFC1918-wide range.
+      internal-proxies: 172\.28\.0\.10

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/filter/XffTrustBoundaryTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/filter/XffTrustBoundaryTest.kt
@@ -1,0 +1,90 @@
+package com.dogGetDrunk.meetjyou.common.filter
+
+import com.google.firebase.FirebaseApp
+import com.oracle.bmc.auth.AuthenticationDetailsProvider
+import com.oracle.bmc.objectstorage.ObjectStorageClient
+import com.oracle.bmc.workrequests.WorkRequestClient
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Documents the trust boundary AuthRateLimitFilter relies on: with
+ * forward-headers-strategy=native, Tomcat's RemoteIpValve parses X-Forwarded-For
+ * right-to-left and only trusts entries appended by a known-internal proxy IP.
+ * nginx (see nginx/nginx.conf) uses $proxy_add_x_forwarded_for, which appends its
+ * own observed remote address rather than forwarding the client's header verbatim -
+ * that append is what actually prevents prefix-injection rate-limit bypass, not the
+ * XFF header alone.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+class XffTrustBoundaryTest : BehaviorSpec() {
+
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Value("\${local.server.port}")
+    private var port: Int = 0
+
+    @MockBean
+    private lateinit var firebaseApp: FirebaseApp
+
+    @MockBean
+    private lateinit var ociAuthProvider: AuthenticationDetailsProvider
+
+    @MockBean
+    private lateinit var objectStorageClient: ObjectStorageClient
+
+    @MockBean
+    private lateinit var workRequestClient: WorkRequestClient
+
+    private fun postRegistrationWithXff(xff: String): Int {
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+        headers.set("X-Forwarded-For", xff)
+        val entity = HttpEntity("{}", headers)
+        val response = restTemplate.postForEntity(
+            "http://localhost:$port/api/v1/auth/registration",
+            entity,
+            String::class.java,
+        )
+        return response.statusCode.value()
+    }
+
+    init {
+        extensions(SpringExtension())
+
+        given("공격자가 매 요청마다 다른 값을 X-Forwarded-For 앞부분에 주입하되, 뒤에는 nginx가 append했을 실제 관측 IP가 고정으로 붙어있을 때") {
+            `when`("registration 한도(5회/분)를 초과해서 요청하면") {
+                then("가짜 앞부분과 무관하게 6번째 요청부터 429가 반환된다") {
+                    val statuses = (1..6).map { i -> postRegistrationWithXff("$i.$i.$i.$i, 203.0.113.99") }
+
+                    statuses.take(5).forEach { it shouldNotBe 429 }
+                    statuses[5] shouldBe 429
+                }
+            }
+        }
+
+        given("(대조군) 프록시가 append 없이 클라이언트가 보낸 X-Forwarded-For 값을 그대로 넘긴다고 가정할 때") {
+            `when`("매 요청마다 유일한 값 하나만 보내면") {
+                then("매번 다른 IP로 인식되어 한도(5회)를 넘겨도 계속 통과한다") {
+                    val statuses = (1..6).map { i -> postRegistrationWithXff("198.51.100.$i") }
+
+                    statuses.forEach { it shouldNotBe 429 }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 기존 성능 감사 백로그에서 "forward-headers-strategy: native가 X-Forwarded-For를 검증 없이 신뢰한다"고 판단했던 항목을 재조사
- 재조사 결과: nginx의 `$proxy_add_x_forwarded_for`(append 방식) + Tomcat `RemoteIpValve`의 우측 파싱 + 8080 미노출 조합으로 이미 스푸핑이 막혀 있음을 실제 임베디드 Tomcat 대상 회귀 테스트로 확인
- 다만 Tomcat의 광범위한 기본 `internal-proxies` 대역(RFC1918 전체)에 암묵적으로 의존하는 상태였으므로, `my_network` subnet과 nginx 컨테이너 IP를 고정하고 `internal-proxies`를 그 IP로 명시적으로 좁혀 방어를 강화

## Test plan
- [x] `XffTrustBoundaryTest` 추가 — nginx의 append 방식을 흉내낸 시나리오(6번째 요청부터 429)와 대조군(append 없이 그대로 전달 시 rate limit 우회됨) 모두 검증
- [x] `./gradlew test` 전체 통과
- [x] `docker compose config`로 compose 파일 문법 검증

## Note
- 테스트 작성 중 `GlobalExceptionHandler`가 깨진 JSON body에 대해 400 대신 500을 반환하는 별개 버그를 발견. 이번 PR 범위 밖이라 별도 백로그로 남김.

🤖 Generated with [Claude Code](https://claude.com/claude-code)