### PR TITLE
perf: Hikari maximum-pool-size 5 → 30 조정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
       keepalive-time: 240000      # 4분마다 idle connection ping
       idle-timeout: 600000
       max-lifetime: 1800000
-      maximum-pool-size: 5        # 프리티어 환경에 맞게 축소 (30으로 늘리면 풀 고갈 해소 확인됨 - OCI 실제 max_connections 확인 후 재검토)
+      maximum-pool-size: 30       # OCI DB max_connections=151 확인 완료, 단일 인스턴스 기준 여유 있게 설정 (50VU 부하테스트에서 풀 고갈 해소 확인됨)
       minimum-idle: 2
       connection-timeout: 5000    # 풀 고갈 시 30초 대기 대신 5초 내 빠른 실패
       connection-test-query: SELECT 1


### PR DESCRIPTION
## Summary
- 운영 OCI MySQL(도커 컨테이너)의 실제 `max_connections=151` 확인
- 이전 부하테스트(50VU)에서 풀 고갈 해소가 검증됐던 30으로 `maximum-pool-size` 상향
- 단일 인스턴스 기준, 151의 20%만 사용해 다른 관리 접속(백업/모니터링 등) 여유 확보

## Test plan
- [x] `./gradlew test` 전체 통과