### PR TITLE
fix: 클라이언트 연결 끊김을 500 에러로 오처리하는 문제 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
@@ -8,6 +8,7 @@ import com.dogGetDrunk.meetjyou.common.exception.business.auth.AuthException
 import com.dogGetDrunk.meetjyou.common.exception.business.jwt.CustomJwtException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.NotFoundException
 import jakarta.servlet.http.HttpServletRequest
+import org.apache.catalina.connector.ClientAbortException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -15,6 +16,7 @@ import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
 @ControllerAdvice
@@ -192,6 +194,21 @@ class GlobalExceptionHandler(
     fun handleNoResourceFoundException(): ResponseEntity<ErrorResponse> {
         val status = HttpStatus.NOT_FOUND
         return ResponseEntity(ErrorResponse(status.value(), ErrorCode.NOT_FOUND), status)
+    }
+
+    /**
+     * The client closed the connection before the response was fully written, so the socket is already
+     * gone: returning a body would only fail again. A void return tells Spring the request is handled.
+     * This is a client-side disconnect, not a server fault — no Discord alert, no ERROR log.
+     */
+    @ExceptionHandler(AsyncRequestNotUsableException::class, ClientAbortException::class)
+    fun handleClientAbortException(e: Exception, request: HttpServletRequest) {
+        log.warn(
+            "Client disconnected before the response was fully written: {} {} ({})",
+            request.method,
+            request.requestURI,
+            e.javaClass.simpleName
+        )
     }
 
     @ExceptionHandler(Exception::class)

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
@@ -3,11 +3,17 @@ package com.dogGetDrunk.meetjyou.common.exception
 import com.dogGetDrunk.meetjyou.common.discord.DiscordAlertService
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
+import java.io.IOException
+import org.apache.catalina.connector.ClientAbortException
 import org.springframework.http.HttpStatus
 import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.security.authorization.AuthorizationResult
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException
+import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver
 
 class GlobalExceptionHandlerTest : BehaviorSpec({
 
@@ -24,6 +30,46 @@ class GlobalExceptionHandlerTest : BehaviorSpec({
 
                 response.statusCode shouldBe HttpStatus.FORBIDDEN
                 response.body?.errorCode shouldBe ErrorCode.ACCESS_DENIED.name
+            }
+        }
+    }
+
+    given("클라이언트가 응답을 다 받기 전에 연결을 끊으면") {
+        `when`("AsyncRequestNotUsableException이 발생하면") {
+            then("500 알림을 Discord로 보내지 않는다") {
+                val exception = AsyncRequestNotUsableException(
+                    "ServletOutputStream failed to flush",
+                    IOException("Broken pipe")
+                )
+                clearMocks(discordAlertService)
+
+                sut.handleClientAbortException(exception, request)
+
+                verify(exactly = 0) { discordAlertService.sendAlert(any(), any(), any(), any(), any()) }
+            }
+        }
+
+        `when`("ClientAbortException이 발생하면") {
+            then("500 알림을 Discord로 보내지 않는다") {
+                clearMocks(discordAlertService)
+
+                sut.handleClientAbortException(ClientAbortException(IOException("Broken pipe")), request)
+
+                verify(exactly = 0) { discordAlertService.sendAlert(any(), any(), any(), any(), any()) }
+            }
+        }
+
+        `when`("예외 핸들러를 조회하면") {
+            then("catch-all 핸들러가 아닌 클라이언트 이탈 전용 핸들러가 선택된다") {
+                val resolver = ExceptionHandlerMethodResolver(GlobalExceptionHandler::class.java)
+                val exception = AsyncRequestNotUsableException(
+                    "ServletOutputStream failed to flush",
+                    IOException("Broken pipe")
+                )
+
+                val method = resolver.resolveMethod(exception)
+
+                method?.name shouldBe "handleClientAbortException"
             }
         }
     }


### PR DESCRIPTION
## Summary
- `GET /api/v1/posts`에서 발생한 500 에러 조사 결과, 클라이언트가 응답 전송 중 연결을 끊어 `AsyncRequestNotUsableException`(broken pipe)이 catch-all 핸들러로 흘러들어가던 문제였음
- 서버 장애가 아닌 클라이언트 이탈임에도 ERROR 로그 + Discord 500 알림이 발생해 노이즈가 됨
- `AsyncRequestNotUsableException`, `ClientAbortException` 전용 핸들러를 추가해 WARN 한 줄만 남기고 알림은 보내지 않도록 수정

## Test plan
- [x] `GlobalExceptionHandlerTest`에 신규 핸들러 케이스 3건 추가 (Discord 알림 미발생 2건 + 핸들러 라우팅 검증 1건)
- [x] `./gradlew test` 전체 통과

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>