### PR TITLE
fix: 코드 리뷰 발견 이슈 및 GlobalExceptionHandler 500 오처리 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandler.kt
@@ -10,44 +10,51 @@ import com.dogGetDrunk.meetjyou.common.exception.business.notFound.NotFoundExcep
 import jakarta.servlet.http.HttpServletRequest
 import org.apache.catalina.connector.ClientAbortException
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.ResponseEntity
 import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.context.request.ServletWebRequest
+import org.springframework.web.context.request.WebRequest
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import org.springframework.web.servlet.resource.NoResourceFoundException
 
+/**
+ * Extends ResponseEntityExceptionHandler so every built-in Spring MVC exception
+ * (HttpMessageNotReadableException, MissingServletRequestParameterException,
+ * HttpRequestMethodNotSupportedException, etc. - see handleExceptionInternal below)
+ * is mapped to the correct status through a single override, instead of requiring a
+ * new @ExceptionHandler each time one is found leaking through as a 500.
+ */
 @ControllerAdvice
 class GlobalExceptionHandler(
     private val discordAlertService: DiscordAlertService
-) {
+) : ResponseEntityExceptionHandler() {
 
     private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
-    @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleValidationException(
+    public override fun handleMethodArgumentNotValid(
         e: MethodArgumentNotValidException,
-        request: HttpServletRequest
-    ): ResponseEntity<ErrorResponse> {
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any> {
         log.info("Handling MethodArgumentNotValidException.", e)
 
         val values = e.bindingResult.fieldErrors.map { error ->
             "[${error.field}] ${error.defaultMessage}"
         }
 
-        discordAlertService.sendAlert(
-            request = request,
-            status = HttpStatus.BAD_REQUEST.value(),
-            exceptionClass = e.javaClass.simpleName,
-            summary = "Validation failed",
-            detail = values.joinToString("\n")
-        )
+        alert(request, HttpStatus.BAD_REQUEST.value(), e.javaClass.simpleName, "Validation failed", values.joinToString("\n"))
 
-        val status = HttpStatus.BAD_REQUEST
-        val errorResponse = ErrorResponse(status.value(), ErrorCode.INVALID_INPUT_VALUE, values)
-        return ResponseEntity(errorResponse, status)
+        val httpStatus = HttpStatus.BAD_REQUEST
+        val errorResponse = ErrorResponse(httpStatus.value(), ErrorCode.INVALID_INPUT_VALUE, values)
+        return ResponseEntity(errorResponse, httpStatus)
     }
 
     @ExceptionHandler(DuplicateException::class)
@@ -190,19 +197,38 @@ class GlobalExceptionHandler(
         return ResponseEntity(errorResponse, status)
     }
 
-    @ExceptionHandler(NoResourceFoundException::class)
-    fun handleNoResourceFoundException(): ResponseEntity<ErrorResponse> {
-        val status = HttpStatus.NOT_FOUND
-        return ResponseEntity(ErrorResponse(status.value(), ErrorCode.NOT_FOUND), status)
+    public override fun handleNoResourceFoundException(
+        e: NoResourceFoundException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        val httpStatus = HttpStatus.NOT_FOUND
+        return ResponseEntity(ErrorResponse(httpStatus.value(), ErrorCode.NOT_FOUND), httpStatus)
     }
 
     /**
      * The client closed the connection before the response was fully written, so the socket is already
-     * gone: returning a body would only fail again. A void return tells Spring the request is handled.
-     * This is a client-side disconnect, not a server fault — no Discord alert, no ERROR log.
+     * gone: returning a body would only fail again. This is a client-side disconnect, not a server
+     * fault — no Discord alert, no ERROR log.
      */
-    @ExceptionHandler(AsyncRequestNotUsableException::class, ClientAbortException::class)
-    fun handleClientAbortException(e: Exception, request: HttpServletRequest) {
+    @ExceptionHandler(ClientAbortException::class)
+    fun handleClientAbortException(e: ClientAbortException, request: HttpServletRequest) {
+        logClientDisconnect(request, e)
+    }
+
+    /**
+     * AsyncRequestNotUsableException is one of the exception types ResponseEntityExceptionHandler
+     * already dispatches via its inherited handleException(), so it must be overridden here rather
+     * than declared as a new @ExceptionHandler - doing both would register two candidate methods for
+     * the same exception type and fail with an "Ambiguous @ExceptionHandler method mapped" error.
+     */
+    public override fun handleAsyncRequestNotUsableException(e: AsyncRequestNotUsableException, request: WebRequest): ResponseEntity<Any>? {
+        logClientDisconnect(request.asServletRequest(), e)
+        return null
+    }
+
+    private fun logClientDisconnect(request: HttpServletRequest, e: Exception) {
         log.warn(
             "Client disconnected before the response was fully written: {} {} ({})",
             request.method,
@@ -242,4 +268,42 @@ class GlobalExceptionHandler(
         val errorResponse = ErrorResponse(status.value(), ErrorCode.INTERNAL_SERVER_ERROR)
         return ResponseEntity(errorResponse, status)
     }
+
+    /**
+     * Single interception point for every built-in Spring MVC exception not given a dedicated
+     * override above - HttpMessageNotReadableException, MissingServletRequestParameterException,
+     * MethodArgumentTypeMismatchException, HttpRequestMethodNotSupportedException,
+     * HttpMediaTypeNotSupportedException, NoHandlerFoundException, MaxUploadSizeExceededException,
+     * and the rest of the ~20 types listed in ResponseEntityExceptionHandler#handleException.
+     * Maps them all to their correct status code (typically 400) instead of letting them fall
+     * through to the catch-all Exception handler as a 500.
+     */
+    public override fun handleExceptionInternal(
+        e: Exception,
+        body: Any?,
+        headers: HttpHeaders,
+        statusCode: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any> {
+        val httpStatus = HttpStatus.valueOf(statusCode.value())
+        log.info("Handling built-in Spring MVC exception: {}", e.javaClass.simpleName, e)
+
+        alert(request, httpStatus.value(), e.javaClass.simpleName, e.message ?: httpStatus.reasonPhrase, null)
+
+        val message = e.message ?: httpStatus.reasonPhrase
+        val errorResponse = ErrorResponse(httpStatus.value(), ErrorCode.INVALID_INPUT_VALUE.name, message)
+        return ResponseEntity(errorResponse, httpStatus)
+    }
+
+    private fun alert(request: WebRequest, status: Int, exceptionClass: String, summary: String, detail: String?) {
+        discordAlertService.sendAlert(
+            request = request.asServletRequest(),
+            status = status,
+            exceptionClass = exceptionClass,
+            summary = summary,
+            detail = detail
+        )
+    }
+
+    private fun WebRequest.asServletRequest(): HttpServletRequest = (this as ServletWebRequest).request
 }

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/exception/GlobalExceptionHandlerTest.kt
@@ -9,16 +9,22 @@ import io.mockk.verify
 import jakarta.servlet.http.HttpServletRequest
 import java.io.IOException
 import org.apache.catalina.connector.ClientAbortException
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.authorization.AuthorizationDeniedException
 import org.springframework.security.authorization.AuthorizationResult
+import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException
 import org.springframework.web.method.annotation.ExceptionHandlerMethodResolver
+import org.springframework.web.servlet.resource.NoResourceFoundException
 
 class GlobalExceptionHandlerTest : BehaviorSpec({
 
     val discordAlertService = mockk<DiscordAlertService>(relaxed = true)
     val request = mockk<HttpServletRequest>(relaxed = true)
+    val webRequest = ServletWebRequest(request)
     val sut = GlobalExceptionHandler(discordAlertService)
 
     given("@PreAuthorize에 의해 AuthorizationDeniedException이 발생하면") {
@@ -34,6 +40,33 @@ class GlobalExceptionHandlerTest : BehaviorSpec({
         }
     }
 
+    given("요청 본문이 파싱 불가능한 JSON이면") {
+        `when`("HttpMessageNotReadableException이 발생하면") {
+            then("500이 아닌 400을 반환한다") {
+                val exception = HttpMessageNotReadableException("JSON parse error")
+
+                val response = sut.handleExceptionInternal(exception, null, HttpHeaders(), HttpStatus.BAD_REQUEST, webRequest)
+
+                response.statusCode shouldBe HttpStatus.BAD_REQUEST
+                (response.body as ErrorResponse).errorCode shouldBe ErrorCode.INVALID_INPUT_VALUE.name
+            }
+        }
+    }
+
+    given("존재하지 않는 정적 리소스를 요청하면") {
+        `when`("NoResourceFoundException이 발생하면") {
+            then("404를 반환하고 Discord 알림을 보내지 않는다") {
+                val exception = NoResourceFoundException(HttpMethod.GET, "/no-such-file")
+                clearMocks(discordAlertService)
+
+                val response = sut.handleNoResourceFoundException(exception, HttpHeaders(), HttpStatus.NOT_FOUND, webRequest)
+
+                response.statusCode shouldBe HttpStatus.NOT_FOUND
+                verify(exactly = 0) { discordAlertService.sendAlert(any(), any(), any(), any(), any()) }
+            }
+        }
+    }
+
     given("클라이언트가 응답을 다 받기 전에 연결을 끊으면") {
         `when`("AsyncRequestNotUsableException이 발생하면") {
             then("500 알림을 Discord로 보내지 않는다") {
@@ -43,7 +76,7 @@ class GlobalExceptionHandlerTest : BehaviorSpec({
                 )
                 clearMocks(discordAlertService)
 
-                sut.handleClientAbortException(exception, request)
+                sut.handleAsyncRequestNotUsableException(exception, webRequest)
 
                 verify(exactly = 0) { discordAlertService.sendAlert(any(), any(), any(), any(), any()) }
             }
@@ -60,14 +93,10 @@ class GlobalExceptionHandlerTest : BehaviorSpec({
         }
 
         `when`("예외 핸들러를 조회하면") {
-            then("catch-all 핸들러가 아닌 클라이언트 이탈 전용 핸들러가 선택된다") {
+            then("클라이언트 이탈 전용 핸들러가 선택된다") {
                 val resolver = ExceptionHandlerMethodResolver(GlobalExceptionHandler::class.java)
-                val exception = AsyncRequestNotUsableException(
-                    "ServletOutputStream failed to flush",
-                    IOException("Broken pipe")
-                )
 
-                val method = resolver.resolveMethod(exception)
+                val method = resolver.resolveMethod(ClientAbortException(IOException("Broken pipe")))
 
                 method?.name shouldBe "handleClientAbortException"
             }


### PR DESCRIPTION
## Summary
- 전체 코드 리뷰에서 발견된 Critical/High/Medium 이슈 일괄 수정
- CORS localhost 제한 원복
- 레거시 파티의 ChatRoom 누락으로 인한 내 파티 목록 500 에러 수정
- `GlobalExceptionHandler`가 Spring MVC 내장 예외(`HttpMessageNotReadableException` 등)를 500으로 오처리하던 문제를 `ResponseEntityExceptionHandler` 상속 방식으로 근본 해결 — 예외 타입별로 하나씩 핸들러를 추가하지 않아도 내장 예외 전체가 올바른 상태 코드에 매핑됨

## Test plan
- [x] `./gradlew test` 전체 통과
- [x] `GlobalExceptionHandlerTest`에 `HttpMessageNotReadableException` → 400, `NoResourceFoundException` → 404(알림 없음) 회귀 테스트 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)