### PR TITLE
docs: 프로젝트 CLAUDE.md를 전역 자립성 표준에 맞춰 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,17 +20,17 @@ SPRING_PROFILES_ACTIVE=dev,db,secrets \
 ./gradlew test --tests "FullyQualifiedClass.methodName"  # single test
 ```
 
-## Testing
-
-- 새로운 기능을 구현한 이후엔 반드시 해당 기능을 검증하는 테스트 코드를 추가할 것
-- 기능 추가 또는 코드 수정 후 최종 반영 전 항상 `./gradlew test`로 전체 테스트를 실행해 오류가 없는지 확인할 것
-
 ## Code Style
 
+- Kotlin coding conventions
 - No wildcard imports
-- Follow Kotlin coding conventions
-- All log messages in English
-- All code comments in English — no Korean comments
+- Logs & comments in English (docs/commits in Korean)
+- Magic numbers / repeated strings → constants
+
+## Testing
+
+- New features ship with unit + integration tests
+- Run full `./gradlew test` before finalizing any change; report actual output
 
 ## Conventions
 
@@ -54,7 +54,7 @@ return GetPartyResponse.of(party)   // in service
 ```
 
 ### Method length
-30-line hard cap on function bodies. Extract private helpers named `validateXxx` / `buildXxx` / `resolveXxx`.
+30-line hard cap on function bodies. Extract private helpers (`validateXxx` / `buildXxx` / `resolveXxx`).
 
 ### N+1 prevention
 Never call a repository inside a loop. Batch-load with `findAllByXxxIn(ids)`, then `groupBy` or `associateBy`.
@@ -94,11 +94,4 @@ com.dogGetDrunk.meetjyou/
 
 ## Compact Instructions
 
-When compacting, preserve:
-- Current task goal and any pending TODOs
-- File paths and class names touched this session
-- Test results (pass/fail counts, failing test names)
-- Key decisions made (e.g., chosen approach, rejected alternatives)
-- Any error messages not yet resolved
-
-Drop: file contents already saved, repeated tool call outputs, resolved errors.
+Context-compaction preserve/drop rules → global CLAUDE.md §9 (pure meta, not a project spec).


### PR DESCRIPTION
## 배경
전역 CLAUDE.md의 문서 작성 표준(§10) 갱신 반영. 핵심 신규 원칙은 **자립성 경계** — 프로젝트 CLAUDE.md는 git에 커밋돼 리뷰어·타 머신에 전달되는 **자립 사양**이므로, 로컬 전역 파일을 런타임 include처럼 참조시키면 안 됨(전역 없으면 규칙 증발).

## 변경
- **스펙 직접 인코딩 복원**: wildcard import 금지·로그/주석 영어·테스트 작성/전체 실행·메서드 길이 헬퍼명(`validateXxx`/`buildXxx`/`resolveXxx`)을 "전역 참조"에서 프로젝트 파일 직접 명시로 되돌림
- **신규 보편 원칙 추가**: 매직넘버·반복 문자열 상수화
- **순수 메타는 포인터로 축약**: `Compact Instructions`(컨텍스트 압축 규칙)는 리뷰어에게 무의미한 순수 메타 → 예외 규정에 따라 전역 §9 포인터 1줄로 축약
- 개조식·서사 제거로 토큰 절약

## 정정 포인트
직전 미커밋 수정은 스펙을 전역 참조로 대체하는 **반대 방향**이었음 — 새 표준(자립성)에 맞춰 스펙은 직접 인코딩, 순수 메타만 포인터로 재분류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)