### PR TITLE
fix: 4xx 에러는 디스코드 알림에서 제외

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/common/discord/DiscordAlertService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/common/discord/DiscordAlertService.kt
@@ -31,6 +31,11 @@ class DiscordAlertService(props: DiscordProperties) {
     ) {
         val client = restClient ?: return
 
+        if (status < 500) {
+            log.debug("Skipping Discord alert for client error: {} {}", status, exceptionClass)
+            return
+        }
+
         val dedupKey = "$status:$exceptionClass:${request.method}:${request.requestURI}"
         if (dedupCache.getIfPresent(dedupKey) != null) {
             log.debug("Skipping duplicate Discord alert: {}", dedupKey)
@@ -38,9 +43,8 @@ class DiscordAlertService(props: DiscordProperties) {
         }
         dedupCache.put(dedupKey, true)
 
-        val isServerError = status >= 500
-        val color = if (isServerError) 16711680 else 16763904
-        val title = if (isServerError) "서버 에러 ($status)" else "클라이언트 에러 ($status)"
+        val color = 16711680
+        val title = "서버 에러 ($status)"
 
         val fields = mutableListOf(
             mapOf("name" to "Path", "value" to "${request.method} ${request.requestURI}", "inline" to false),

--- a/src/test/java/com/dogGetDrunk/meetjyou/common/discord/DiscordAlertServiceTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/common/discord/DiscordAlertServiceTest.kt
@@ -1,0 +1,58 @@
+package com.dogGetDrunk.meetjyou.common.discord
+
+import com.dogGetDrunk.meetjyou.config.DiscordProperties
+import com.sun.net.httpserver.HttpServer
+import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+class DiscordAlertServiceTest : BehaviorSpec({
+
+    val receivedCount = AtomicInteger(0)
+    val server = HttpServer.create(InetSocketAddress(0), 0)
+    server.createContext("/webhook") { exchange ->
+        receivedCount.incrementAndGet()
+        exchange.sendResponseHeaders(204, -1)
+        exchange.close()
+    }
+    server.start()
+    afterSpec { server.stop(0) }
+
+    val sut = DiscordAlertService(DiscordProperties(webhookUrl = "http://localhost:${server.address.port}/webhook"))
+    val request = mockk<HttpServletRequest>()
+    every { request.method } returns "GET"
+    every { request.requestURI } returns "/api/test"
+
+    given("4xx 상태로 알림을 보내면") {
+        `when`("sendAlert를 호출하면") {
+            then("Discord로 전송하지 않는다") {
+                receivedCount.set(0)
+
+                sut.sendAlert(request, 400, "InvalidInputException", "bad request")
+
+                Thread.sleep(300)
+                receivedCount.get() shouldBe 0
+            }
+        }
+    }
+
+    given("5xx 상태로 알림을 보내면") {
+        `when`("sendAlert를 호출하면") {
+            then("Discord로 전송한다") {
+                receivedCount.set(0)
+
+                sut.sendAlert(request, 500, "RuntimeException", "unexpected error")
+
+                eventually(2.seconds) {
+                    receivedCount.get() shouldBe 1
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- 클라이언트 에러(4xx)가 디스코드 알림 채널에 계속 뜨는 문제 해결
- `DiscordAlertService.sendAlert`에서 `status < 500`이면 조기 반환하도록 필터링
- `GlobalExceptionHandler`의 개별 핸들러(400/401/403/404/409)를 하나씩 고치는 대신 서비스 단일 지점에서 처리 — 향후 새 4xx 핸들러가 추가돼도 자동 적용
- 5xx(예상치 못한 서버 에러)는 기존대로 알림 전송

## Test plan
- [x] `DiscordAlertServiceTest` 추가 — 로컬 HTTP 서버로 실제 웹훅 호출 여부 검증 (4xx 미전송 / 5xx 전송)
- [x] `GlobalExceptionHandlerTest` 회귀 확인
- [x] `./gradlew test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)