### PR TITLE
perf: 프로덕션 sweep 실측 기반 Hikari 풀 상향 + Chat 테스트 flaky 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,8 @@ spring:
       keepalive-time: 240000      # 4분마다 idle connection ping
       idle-timeout: 600000
       max-lifetime: 1800000
-      maximum-pool-size: 30       # OCI DB max_connections=151 확인 완료, 단일 인스턴스 기준 여유 있게 설정 (50VU 부하테스트에서 풀 고갈 해소 확인됨)
+      maximum-pool-size: 50       # OCI DB max_connections=151 확인 완료, 여유 있음. 30에서 프로덕션 capacity sweep(70VU) 중
+                                  # actuator hikaricp.connections.pending이 두 자릿수까지 관측되어(active=30 고정) 50으로 상향
       minimum-idle: 2
       connection-timeout: 5000    # 풀 고갈 시 30초 대기 대신 5초 내 빠른 실패
       connection-test-query: SELECT 1

--- a/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatIntegrationTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/chat/ChatIntegrationTest.kt
@@ -129,6 +129,13 @@ class ChatIntegrationTest : BehaviorSpec() {
                     )
 
                     withTimeout(5000L) { received.await() } shouldBe "hello from test"
+
+                    // The broadcast fires mid-transaction, before handleChatMessage's commit
+                    // (post-broadcast work: read-receipt update, notification event publish).
+                    // Give that a moment to settle before cleanup() deletes the room/message rows,
+                    // or a late commit can insert a message referencing an already-deleted room.
+                    delay(300)
+
                     session.disconnect()
                 }
             }


### PR DESCRIPTION
## 배경
PR #118 배포 후 재검증을 위해 프로덕션 capacity sweep을 다시 돌리면서, 서버에서 `docker stats` + `/actuator/metrics/hikaricp.connections.*`를 동시에 수집해 실제 병목을 직접 측정.

## 변경 사항

### perf: HikariCP `maximum-pool-size` 30 → 50 (`application.yml`)
- 5→70VU sweep 동안 40VU 단계부터 `hikaricp.connections.pending` 발생 시작, 70VU 단계에서는 `active`가 30(당시 최대치)에 고정된 채 `pending`이 두 자릿수(최대 22)까지 누적되는 것을 실측으로 확인
- 같은 구간 메모리는 700MB 제한의 40~50%대에 머물러 힙 압박은 배제 — 지난 PR #118에서 세운 "GC pause가 원인일 것" 가설은 이 실측으로 반증되었고, 커넥션 풀 대기가 실제 병목이었음이 확인됨
- MySQL `max_connections=151` 대비 여유 있어 50으로 상향

### fix: `ChatIntegrationTest` race condition
- `ChatService.handleChatMessage`가 `@Transactional` 커밋 전에 WS 브로드캐스트를 보내는 구조라, 테스트가 브로드캐스트 수신 즉시 cleanup으로 넘어가면 뒤늦게 커밋된 `chat_message` row가 FK 위반을 일으키는 flaky 케이스 발견 (직전 PR #118에서 고친 `notification_outbox` 누락 케이스와 동일 근본 원인)
- 수신 후 300ms 여유를 둬서 커밋 정착 시간 확보

## Test plan
- [x] `./gradlew test` 280개 전체 통과
- [ ] 배포 후 capacity sweep 재실행 + 동일 모니터링으로 pending이 실제로 줄었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)