### PR TITLE
fix: 전체 감사에서 발견한 IDOR·동시성·null-safety 버그 수정

### DIFF
--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/ChatReadService.kt
@@ -126,7 +126,8 @@ class ChatReadService(
             userUuid = requesterUuid,
         ) ?: throw ChatRoomAccessDeniedException(requesterUuid.toString())
 
-        val unreadCount = if (membership.lastReadMessageId == null) {
+        val lastReadMessageId = membership.lastReadMessageId
+        val unreadCount = if (lastReadMessageId == null) {
             chatMessageRepository.countByRoom_UuidAndSender_UuidNot(
                 roomUuid = roomUuid,
                 senderUuid = requesterUuid,
@@ -134,7 +135,7 @@ class ChatReadService(
         } else {
             chatMessageRepository.countByRoom_UuidAndIdGreaterThanAndSender_UuidNot(
                 roomUuid = roomUuid,
-                id = membership.lastReadMessageId!!,
+                id = lastReadMessageId,
                 senderUuid = requesterUuid,
             )
         }
@@ -354,13 +355,14 @@ class ChatReadService(
         val previousLastReadMessageId = membership.lastReadMessageId
         membership.updateLastReadMessageId(messageId)
 
-        if (membership.lastReadMessageId != null && membership.lastReadMessageId != previousLastReadMessageId) {
+        val currentLastReadMessageId = membership.lastReadMessageId
+        if (currentLastReadMessageId != null && currentLastReadMessageId != previousLastReadMessageId) {
             chatRoomEventBroadcaster.broadcastChatReadUpdated(
                 roomUuid = roomUuid,
                 partyUuid = partyUuid,
                 readerUserUuid = userUuid,
                 previousLastReadMessageId = previousLastReadMessageId,
-                currentLastReadMessageId = membership.lastReadMessageId!!,
+                currentLastReadMessageId = currentLastReadMessageId,
             )
         }
     }
@@ -382,13 +384,14 @@ class ChatReadService(
         val previousLastReadMessageId = membership.lastReadMessageId
         membership.updateLastReadMessageId(messageId)
 
-        if (membership.lastReadMessageId != null && membership.lastReadMessageId != previousLastReadMessageId) {
+        val currentLastReadMessageId = membership.lastReadMessageId
+        if (currentLastReadMessageId != null && currentLastReadMessageId != previousLastReadMessageId) {
             chatRoomEventBroadcaster.broadcastChatReadUpdated(
                 roomUuid = roomUuid,
                 partyUuid = partyUuid,
                 readerUserUuid = requesterUuid,
                 previousLastReadMessageId = previousLastReadMessageId,
-                currentLastReadMessageId = membership.lastReadMessageId!!,
+                currentLastReadMessageId = currentLastReadMessageId,
             )
         }
     }

--- a/src/main/java/com/dogGetDrunk/meetjyou/chat/connection/ChatSessionTracker.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/chat/connection/ChatSessionTracker.kt
@@ -16,34 +16,42 @@ class ChatSessionTracker {
 
     private val connectedSessions: MutableMap<UUID, MutableMap<UUID, MutableSet<String>>> = ConcurrentHashMap()
 
+    // Every mutation of a room entry — inner-set edits included — runs inside a single
+    // connectedSessions.compute(roomUuid) so the room map and its nested user map are updated
+    // under one lock. This serializes connect/disconnect on the same room, closing two races
+    // the previous check-then-act code had: (1) a concurrent connect adding a session between a
+    // disconnect's isEmpty() check and its key removal, and (2) a connect writing into an inner
+    // map that a disconnect had just pruned from the room (orphaned write). Reads below stay
+    // lock-free, so nested maps remain ConcurrentHashMap / newKeySet for safe concurrent reads.
     fun connectUser(roomUuid: UUID, userUuid: UUID, sessionId: String) {
-        connectedSessions.computeIfAbsent(roomUuid) { ConcurrentHashMap() }
-            .computeIfAbsent(userUuid) { ConcurrentHashMap.newKeySet() }
-            .add(sessionId)
+        connectedSessions.compute(roomUuid) { _, existingUserMap ->
+            val userMap = existingUserMap ?: ConcurrentHashMap()
+            val sessions = userMap[userUuid] ?: ConcurrentHashMap.newKeySet()
+            sessions.add(sessionId)
+            userMap[userUuid] = sessions
+            userMap
+        }
 
         log.debug("User session connected to chat room. roomUuid={}, userUuid={}, sessionId={}", roomUuid, userUuid, sessionId)
     }
 
     fun disconnectUser(roomUuid: UUID, userUuid: UUID, sessionId: String) {
-        val userSessions = connectedSessions[roomUuid] ?: return
-        userSessions[userUuid]?.remove(sessionId)
-
-        if (userSessions[userUuid]?.isEmpty() == true) {
-            userSessions.remove(userUuid)
-        }
-        if (userSessions.isEmpty()) {
-            connectedSessions.remove(roomUuid)
+        connectedSessions.compute(roomUuid) { _, userMap ->
+            if (userMap == null) return@compute null
+            val sessions = userMap[userUuid]
+            sessions?.remove(sessionId)
+            if (sessions.isNullOrEmpty()) userMap.remove(userUuid)
+            if (userMap.isEmpty()) null else userMap
         }
 
         log.debug("User session disconnected from chat room. roomUuid={}, userUuid={}, sessionId={}", roomUuid, userUuid, sessionId)
     }
 
     fun disconnectAllSessions(roomUuid: UUID, userUuid: UUID) {
-        val userSessions = connectedSessions[roomUuid] ?: return
-        userSessions.remove(userUuid)
-
-        if (userSessions.isEmpty()) {
-            connectedSessions.remove(roomUuid)
+        connectedSessions.compute(roomUuid) { _, userMap ->
+            if (userMap == null) return@compute null
+            userMap.remove(userUuid)
+            if (userMap.isEmpty()) null else userMap
         }
 
         log.debug("All sessions disconnected for user in chat room. roomUuid={}, userUuid={}", roomUuid, userUuid)
@@ -54,6 +62,9 @@ class ChatSessionTracker {
     }
 
     fun getConnectedUsers(roomUuid: UUID): Set<UUID> {
-        return connectedSessions[roomUuid]?.keys?.toSet() ?: emptySet()
+        return connectedSessions[roomUuid]
+            ?.filterValues { it.isNotEmpty() }
+            ?.keys?.toSet()
+            ?: emptySet()
     }
 }

--- a/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/plan/PlanService.kt
@@ -109,7 +109,8 @@ class PlanService(
     private fun resolveRecruitStatuses(planUuids: List<UUID>): Map<UUID, PlanRecruitStatus> {
         if (planUuids.isEmpty()) return emptyMap()
         return postRepository.findAllByPlan_UuidIn(planUuids)
-            .associateBy({ it.plan!!.uuid }, { it.toRecruitStatus() })
+            .mapNotNull { post -> post.plan?.let { it.uuid to post.toRecruitStatus() } }
+            .toMap()
     }
 
     private fun Post.toRecruitStatus(): PlanRecruitStatus = when {

--- a/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/post/PostService.kt
@@ -5,6 +5,7 @@ import com.dogGetDrunk.meetjyou.common.exception.business.InvalidInputException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.PostNotFoundException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.PreferenceNotFoundException
 import com.dogGetDrunk.meetjyou.common.exception.business.notFound.UserNotFoundException
+import com.dogGetDrunk.meetjyou.common.exception.business.plan.PlanUpdateAccessDeniedException
 import com.dogGetDrunk.meetjyou.common.exception.business.post.PostUpdateAccessDeniedException
 import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
 import com.dogGetDrunk.meetjyou.chat.room.dto.ChatRoomResponse
@@ -234,6 +235,13 @@ class PostService(
     private fun resolvePlanReference(planUuid: UUID?, isPlanPublic: Boolean?): Pair<Plan, Boolean>? {
         if (planUuid == null) return null
         val plan = planRepository.findByUuid(planUuid) ?: throw PlanNotFoundException(planUuid)
+        // Ownership guard: a post may only reference a plan owned by the author. Without this,
+        // attaching someone else's private plan with isPlanPublic=true would expose it (both
+        // embedded in the post response and made world-readable via PlanAccessGuard).
+        val currentUserUuid = currentUserProvider.uuid
+        if (plan.owner.uuid != currentUserUuid) {
+            throw PlanUpdateAccessDeniedException(planUuid, currentUserUuid)
+        }
         val public = isPlanPublic
             ?: throw InvalidInputException(value = "isPlanPublic", message = "isPlanPublic is required when planUuid is provided")
         return Pair(plan, public)

--- a/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
+++ b/src/main/java/com/dogGetDrunk/meetjyou/user/UserService.kt
@@ -145,6 +145,7 @@ class UserService(
         termsService.recordConsentChange(user, TermsType.MARKETING_EMAIL_EVENTS, emailConsented)
     }
 
+    @Transactional(readOnly = true)
     fun isDuplicateNickname(nickname: String): Boolean {
         val gracePeriodCutoff = Instant.now().minus(NICKNAME_GRACE_PERIOD)
         return userRepository.existsActiveNickname(nickname, gracePeriodCutoff)

--- a/src/test/java/com/dogGetDrunk/meetjyou/chat/connection/ChatSessionTrackerTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/chat/connection/ChatSessionTrackerTest.kt
@@ -3,7 +3,10 @@ package com.dogGetDrunk.meetjyou.chat.connection
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import java.util.UUID
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
 
 class ChatSessionTrackerTest : BehaviorSpec() {
 
@@ -46,6 +49,58 @@ class ChatSessionTrackerTest : BehaviorSpec() {
                     sut.disconnectAllSessions(roomUuid, userUuid)
 
                     sut.isUserConnected(roomUuid, userUuid) shouldBe false
+                }
+            }
+        }
+
+        given("한 방에 여러 유저가 접속했을 때") {
+            val sut = ChatSessionTracker()
+            val roomUuid = UUID.randomUUID()
+            val userA = UUID.randomUUID()
+            val userB = UUID.randomUUID()
+
+            `when`("한 유저의 모든 세션이 끊기면") {
+                then("getConnectedUsers는 세션이 남아있는 유저만 반환한다") {
+                    sut.connectUser(roomUuid, userA, "a1")
+                    sut.connectUser(roomUuid, userB, "b1")
+
+                    sut.disconnectUser(roomUuid, userA, "a1")
+
+                    sut.getConnectedUsers(roomUuid) shouldContainExactlyInAnyOrder listOf(userB)
+                }
+            }
+        }
+
+        given("동시성: 마지막 세션 해제와 새 세션 접속이 같은 방/유저에서 경쟁할 때") {
+            `when`("한 스레드가 기존 세션을 끊는 동시에 다른 스레드가 새 세션을 붙이면") {
+                then("살아있는 새 세션 덕분에 접속 상태가 유지된다 (presence 유실 없음)") {
+                    val sut = ChatSessionTracker()
+                    val roomUuid = UUID.randomUUID()
+                    val userUuid = UUID.randomUUID()
+                    val pool = Executors.newFixedThreadPool(2)
+                    try {
+                        repeat(5000) {
+                            sut.connectUser(roomUuid, userUuid, "old")
+                            val barrier = CyclicBarrier(2)
+                            val disconnect = pool.submit {
+                                barrier.await()
+                                sut.disconnectUser(roomUuid, userUuid, "old")
+                            }
+                            val connect = pool.submit {
+                                barrier.await()
+                                sut.connectUser(roomUuid, userUuid, "new")
+                            }
+                            disconnect.get()
+                            connect.get()
+
+                            // "new" always outlives "old", so the user must remain connected.
+                            sut.isUserConnected(roomUuid, userUuid) shouldBe true
+
+                            sut.disconnectAllSessions(roomUuid, userUuid)
+                        }
+                    } finally {
+                        pool.shutdownNow()
+                    }
                 }
             }
         }

--- a/src/test/java/com/dogGetDrunk/meetjyou/post/PostPlanOwnershipTest.kt
+++ b/src/test/java/com/dogGetDrunk/meetjyou/post/PostPlanOwnershipTest.kt
@@ -1,0 +1,113 @@
+package com.dogGetDrunk.meetjyou.post
+
+import com.dogGetDrunk.meetjyou.auth.CustomUserPrincipal
+import com.dogGetDrunk.meetjyou.common.exception.business.plan.PlanUpdateAccessDeniedException
+import com.dogGetDrunk.meetjyou.common.util.CurrentUserProvider
+import com.dogGetDrunk.meetjyou.notificationcenter.support.NotificationCenterFixtures
+import com.dogGetDrunk.meetjyou.party.PartyService
+import com.dogGetDrunk.meetjyou.plan.MarkerRepository
+import com.dogGetDrunk.meetjyou.plan.PlanRepository
+import com.dogGetDrunk.meetjyou.plan.support.PlanFixtures
+import com.dogGetDrunk.meetjyou.post.dto.UpdatePostRequest
+import com.dogGetDrunk.meetjyou.post.view.PostViewService
+import com.dogGetDrunk.meetjyou.preference.CompPreferenceRepository
+import com.dogGetDrunk.meetjyou.preference.PreferenceRepository
+import com.dogGetDrunk.meetjyou.user.UserRepository
+import com.dogGetDrunk.meetjyou.user.support.UserFixtures
+import com.dogGetDrunk.meetjyou.userparty.UserPartyRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+
+/**
+ * Regression: a post must not be able to reference a plan the author does not own.
+ * Without the ownership guard in resolvePlanReference, attaching someone else's private
+ * plan with isPlanPublic=true would leak it (embedded in the post response, and made
+ * world-readable via PlanAccessGuard#existsByPlan_UuidAndIsPlanPublicTrue).
+ */
+class PostPlanOwnershipTest : BehaviorSpec() {
+
+    private val postRepository = mockk<PostRepository>(relaxed = true)
+    private val userRepository = mockk<UserRepository>(relaxed = true)
+    private val compPreferenceRepository = mockk<CompPreferenceRepository>(relaxed = true)
+    private val preferenceRepository = mockk<PreferenceRepository>(relaxed = true)
+    private val partyService = mockk<PartyService>(relaxed = true)
+    private val planRepository = mockk<PlanRepository>(relaxed = true)
+    private val markerRepository = mockk<MarkerRepository>(relaxed = true)
+    private val userPartyRepository = mockk<UserPartyRepository>(relaxed = true)
+    private val postViewService = mockk<PostViewService>(relaxed = true)
+    private val currentUserProvider = mockk<CurrentUserProvider>(relaxed = true)
+    private val sut = PostService(
+        postRepository, userRepository, compPreferenceRepository, preferenceRepository,
+        partyService, planRepository, markerRepository, userPartyRepository, postViewService,
+        currentUserProvider,
+    )
+
+    override fun isolationMode() = IsolationMode.InstancePerLeaf
+
+    private fun updateRequest(post: Post, planUuid: java.util.UUID?, isPlanPublic: Boolean?) = UpdatePostRequest(
+        title = post.title,
+        content = post.content,
+        isInstant = post.isInstant,
+        itinStart = post.itinStart,
+        itinFinish = post.itinFinish,
+        location = post.location,
+        capacity = post.capacity,
+        companionSpec = null,
+        planUuid = planUuid,
+        isPlanPublic = isPlanPublic,
+    )
+
+    init {
+        val user = UserFixtures.user()
+        val party = NotificationCenterFixtures.party()
+        val post = NotificationCenterFixtures.post(party, user)
+
+        beforeEach {
+            clearAllMocks()
+            val principal = CustomUserPrincipal(user.uuid, user.email)
+            SecurityContextHolder.getContext().authentication =
+                UsernamePasswordAuthenticationToken(principal, null, emptyList())
+            every { currentUserProvider.uuid } returns user.uuid
+            every { postRepository.findByUuid(post.uuid) } returns post
+        }
+
+        afterEach { SecurityContextHolder.clearContext() }
+
+        given("updatePost 호출 시 다른 유저가 소유한 planUuid가 전달되면") {
+            `when`("소유권 없는 플랜을 모집글에 연결하려 하면") {
+                then("PlanUpdateAccessDeniedException(403)이 발생하고 plan은 바뀌지 않는다") {
+                    val otherUser = UserFixtures.user(email = "other@example.com", nickname = "other")
+                    val otherPlan = PlanFixtures.plan(owner = otherUser)
+                    every { planRepository.findByUuid(otherPlan.uuid) } returns otherPlan
+
+                    shouldThrow<PlanUpdateAccessDeniedException> {
+                        sut.updatePost(post.uuid, updateRequest(post, otherPlan.uuid, true))
+                    }
+
+                    post.plan shouldBe null
+                }
+            }
+        }
+
+        given("updatePost 호출 시 본인이 소유한 planUuid가 전달되면") {
+            `when`("소유한 플랜을 모집글에 연결하면") {
+                then("정상적으로 연결된다") {
+                    val ownPlan = PlanFixtures.plan(owner = user)
+                    every { planRepository.findByUuid(ownPlan.uuid) } returns ownPlan
+
+                    sut.updatePost(post.uuid, updateRequest(post, ownPlan.uuid, true))
+
+                    post.plan shouldBe ownPlan
+                    post.isPlanPublic shouldBe true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
프로젝트 전체(327 Kotlin 파일)를 도메인별로 감사해 발견한 **실제 버그**를 수정. 스타일 지적이 아닌 정합성·보안·동시성 결함만 대상. 아키텍처/정책 판단이 필요한 항목은 수정하지 않고 아래 "후속 논의 대상"에 정리.

## 수정 내역

### 🔴 HIGH — IDOR: 모집글이 타 유저의 비공개 plan 노출 (`PostService`)
- `resolvePlanReference`가 소유권 검증 없이 `findByUuid`만 수행
- 공격자가 피해자의 비공개 plan UUID를 `isPlanPublic=true`로 자기 모집글에 첨부 → (1) `GetPostResponse`에 plan+markers embed로 직접 열람, (2) `PlanAccessGuard`가 `existsByPlan_UuidAndIsPlanPublicTrue=true`로 판단해 `GET /plans/{victim}`까지 전체 공개
- `PartyService.resolveOwnedPlan`과 동일 패턴으로 소유권 검증 추가 → `PlanUpdateAccessDeniedException`(403)
- 회귀 테스트 `PostPlanOwnershipTest` 추가

### 🟠 MED — 동시성: `ChatSessionTracker` presence 유실 레이스
- `disconnectUser`의 check-then-remove가 비원자적 → 동시 `connectUser`가 붙인 세션까지 삭제해 접속 중인데 offline 오판
- `connectUser`의 `.add`도 락 밖 실행 → disconnect가 직전에 prune한 inner map에 write하는 orphaned-write 레이스
- room 엔트리의 모든 변경(내부 세트 편집 포함)을 단일 `connectedSessions.compute(roomUuid)` 락으로 직렬화해 두 레이스 모두 제거 (읽기 경로는 lock-free 유지)
- 동시성 스트레스 테스트(5000회) 추가

### 🟡 LOW — 컨벤션/안정성
- `!!` 4곳 제거 (`PlanService`, `ChatReadService`×3) — `?:` / 로컬 val 캡처
- `UserService.isDuplicateNickname`에 `@Transactional(readOnly=true)` 보강

## 검증
- `./gradlew test` 전체 통과 (동시성 스트레스 5000회, IDOR 회귀 포함)

## 후속 논의 대상 (이 PR 범위 밖 — 정책/아키텍처 결정 필요)
- **알림 outbox가 originating tx 밖에서 기록됨** (`@TransactionalEventListener(AFTER_COMMIT)`+`REQUIRES_NEW`) — 커밋~리스너 사이 크래시 시 알림 유실. rule 문서의 "originating tx 내 기록" 불변식과 상충
- **`SENDING` 상태 고착 복구 없음** — dispatcher 크래시 시 영구 미전송. reaper(lease 타임아웃) 필요
- **멀티토큰 dispatch 비멱등** — 일부 토큰 실패 시 전체 재전송(중복 push) / 단일 permanent 실패 시 전체 DEAD
- **WS 브로드캐스트가 커밋 전 발신** (`ChatService.handleChatMessage`) — 이후 롤백 시 유령 메시지
- **닉네임 30일 유예 재사용 모순** — 중복체크 API(`existsActiveNickname`)와 등록 검증(`existsByNickname`)이 불일치 → 유예 후에도 재사용 불가
- **GENDER/AGE preference 부재 시 프로필/유저목록 404** — dev/loadtest 유저에서 발생. 응답 스키마(nullable) 변경 필요
- **join/nickname 등록의 TOCTOU 500** — 진정한 동시 요청 시 유니크 제약 위반이 500. (팀 기존 패턴은 사전체크로 순차 재시도만 커버)
- **refresh token 회전 비원자적** — 동시 요청 시 double-spend 창
- **actuator 관리 포트 blanket permitAll** — 8081 방화벽 미격리 시 정보 노출
- `TermsBadRequestException`(현재 dead code)이 핸들러 부재로 500 매핑 — `InvalidInputException` 상속 또는 `BusinessException` 폴백 핸들러 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)